### PR TITLE
Convert to using free arrows.

### DIFF
--- a/funflow.cabal
+++ b/funflow.cabal
@@ -46,11 +46,13 @@ Library
    Build-depends:
                  base                    >= 4.6 && <5
                , clock
+               , constraints
                , store
                , text
                , containers
                , cryptonite
                , directory
+               , exceptions
                , filepath
                , ghc-prim
                , hostname
@@ -80,7 +82,7 @@ Test-suite test-funflow
                      , funflow
                      , hedis
                      , text
-
+                     , exceptions
 
 Test-suite unit-tests
   type:               exitcode-stdio-1.0

--- a/funflow.cabal
+++ b/funflow.cabal
@@ -27,12 +27,14 @@ Library
    default-language:  Haskell2010
 
    Exposed-modules:
-                     Control.FunFlow
+                     Control.Arrow.Free
+                   , Control.FunFlow
                    , Control.FunFlow.Base
                    , Control.FunFlow.Utils
                    , Control.FunFlow.ContentHashable
                    , Control.FunFlow.ContentStore
                    , Control.FunFlow.External
+                   , Control.FunFlow.Diagram
                    , Control.FunFlow.External.Coordinator
                    , Control.FunFlow.External.Coordinator.Memory
                    , Control.FunFlow.Steps
@@ -59,6 +61,7 @@ Library
                , random
                , stm
                , text
+               , transformers
                , pretty
                , bytestring
                , hedis

--- a/src/Control/Arrow/Free.hs
+++ b/src/Control/Arrow/Free.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE Rank2Types          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators       #-}
+
+module Control.Arrow.Free
+  ( Free
+  , effect
+  , evalA
+  , Choice
+  , effectChoice
+  , evalChoice
+  , mapA
+  ) where
+
+import           Control.Arrow
+import           Control.Category
+import           Data.Either      (Either (..))
+import           Data.Function    (const, flip, ($))
+import           Data.List        (uncons)
+import           Data.Maybe       (maybe)
+import           Data.Tuple       (uncurry)
+
+type x ~> y = forall a b. x a b -> y a b
+
+data Free eff a b where
+  Pure :: (a -> b) -> Free eff a b
+  Effect :: eff a b -> Free eff a b
+  Seq :: Free eff a b -> Free eff b c -> Free eff a c
+  Par :: Free eff a1 b1 -> Free eff a2 b2 -> Free eff (a1, a2) (b1, b2)
+
+instance Category (Free eff) where
+  id = Pure id
+  (.) = flip Seq
+
+instance Arrow (Free eff) where
+  arr = Pure
+  first f = Par f id
+  second f = Par id f
+  (***) = Par
+
+-- | Lift an effect into an arrow.
+effect :: eff a b -> Free eff a b
+effect = Effect
+
+-- | Evaluate given an implicit arrow
+evalA :: forall eff arr a0 b0. (Arrow arr)
+      => (eff ~> arr)
+      -> Free eff a0 b0
+      -> arr a0 b0
+evalA exec = go
+  where
+    go :: forall a b. Free eff a b -> arr a b
+    go freeA = case freeA of
+        Pure f     -> arr f
+        Seq f1 f2  -> go f2 . go f1
+        Par f1 f2  -> go f1 *** go f2
+        Effect eff -> exec eff
+
+--------------------------------------------------------------------------------
+-- ArrowChoice
+--------------------------------------------------------------------------------
+
+newtype Choice eff a b = Choice {
+  runChoice :: forall ac. ArrowChoice ac => (eff ~> ac) -> ac a b
+}
+
+instance Category (Choice eff) where
+  id = Choice $ const id
+  Choice f . Choice g = Choice $ \x -> f x . g x
+
+instance Arrow (Choice eff) where
+  arr a = Choice $ const $ arr a
+  first (Choice a) = Choice $ \f -> first (a f)
+  second (Choice a) = Choice $ \f -> second (a f)
+  (Choice a) *** (Choice b) = Choice $ \f -> a f *** b f
+
+instance ArrowChoice (Choice eff) where
+  left (Choice a) = Choice $ \f -> left (a f)
+  right (Choice a) = Choice $ \f -> right (a f)
+  (Choice a) ||| (Choice b) = Choice $ \f -> a f ||| b f
+
+effectChoice :: eff a b -> Choice eff a b
+effectChoice a = Choice $ \f -> f a
+
+evalChoice :: forall eff arr a0 b0. (ArrowChoice arr)
+            => (eff ~> arr)
+            -> Choice eff a0 b0
+            -> arr a0 b0
+evalChoice f a = runChoice a f
+
+-- | Map an arrow over a list.
+mapA :: ArrowChoice a => a b c -> a [b] [c]
+mapA f = arr (maybe (Left ()) Right . uncons)
+      >>> (arr (const []) ||| ((f *** mapA f) >>> arr (uncurry (:))))

--- a/src/Control/Arrow/Free.hs
+++ b/src/Control/Arrow/Free.hs
@@ -1,31 +1,70 @@
-{-# LANGUAGE Arrows              #-}
-{-# LANGUAGE GADTs               #-}
-{-# LANGUAGE NoImplicitPrelude   #-}
-{-# LANGUAGE Rank2Types          #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeOperators       #-}
+-- {-# LANGUAGE AllowAmbiguousTypes   #-}
+{-# LANGUAGE Arrows                #-}
+{-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE InstanceSigs          #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NoImplicitPrelude     #-}
+{-# LANGUAGE PolyKinds             #-}
+{-# LANGUAGE Rank2Types            #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
 
 module Control.Arrow.Free
   ( Free
-  , effect
-  , evalA
   , Choice
-  , effectChoice
-  , evalChoice
+  , ErrorChoice
+  , effect
+  , eval
+    -- * ArrowError
+  , ArrowError(..)
+    -- * Arrow functions
   , mapA
   , filterA
   ) where
 
 import           Control.Arrow
 import           Control.Category
-import           Data.Bool        (Bool)
-import           Data.Either      (Either (..))
-import           Data.Function    (const, flip, ($))
-import           Data.List        (uncons)
-import           Data.Maybe       (maybe)
-import           Data.Tuple       (uncurry)
+import           Control.Monad.Catch (Exception, MonadCatch)
+import qualified Control.Monad.Catch as Monad.Catch
+import           Data.Bool           (Bool)
+import           Data.Constraint     (Constraint, Dict (..), mapDict, weaken1,
+                                      weaken2)
+import           Data.Either         (Either (..))
+import           Data.Function       (const, flip, ($))
+import           Data.List           (uncons)
+import           Data.Maybe          (maybe)
+import           Data.Tuple          (curry, uncurry)
 
 type x ~> y = forall a b. x a b -> y a b
+
+--------------------------------------------------------------------------------
+-- FreeArrowLike
+--------------------------------------------------------------------------------
+
+-- | Small class letting us define `eval` and `effect` generally over
+--   multiple free structures
+class FreeArrowLike fal where
+  type Ctx fal :: (k -> k -> *) -> Constraint
+  effect :: eff a b -> fal eff a b
+  eval :: forall eff arr a b. ((Ctx fal) arr)
+       => (eff ~> arr)
+       -> fal eff a b
+       -> arr a b
+
+-- | Annoying hackery to let us tuple constraints and still use 'effect'
+--   and 'eval'
+class Join ( a :: k -> Constraint) (b :: k -> Constraint) (x :: k) where
+  ctx :: Dict (a x, b x)
+instance (a x, b x) => Join a b x where
+  ctx = Dict
+
+--------------------------------------------------------------------------------
+-- Arrow
+--------------------------------------------------------------------------------
 
 data Free eff a b where
   Pure :: (a -> b) -> Free eff a b
@@ -43,23 +82,25 @@ instance Arrow (Free eff) where
   second f = Par id f
   (***) = Par
 
--- | Lift an effect into an arrow.
-effect :: eff a b -> Free eff a b
-effect = Effect
+instance FreeArrowLike Free where
+  type Ctx Free = Arrow
+  -- | Lift an effect into an arrow.
+  effect :: eff a b -> Free eff a b
+  effect = Effect
 
--- | Evaluate given an implicit arrow
-evalA :: forall eff arr a0 b0. (Arrow arr)
-      => (eff ~> arr)
-      -> Free eff a0 b0
-      -> arr a0 b0
-evalA exec = go
-  where
-    go :: forall a b. Free eff a b -> arr a b
-    go freeA = case freeA of
-        Pure f     -> arr f
-        Seq f1 f2  -> go f2 . go f1
-        Par f1 f2  -> go f1 *** go f2
-        Effect eff -> exec eff
+  -- | Evaluate given an implicit arrow
+  eval :: forall eff arr a0 b0. (Arrow arr)
+        => (eff ~> arr)
+        -> Free eff a0 b0
+        -> arr a0 b0
+  eval exec = go
+    where
+      go :: forall a b. Free eff a b -> arr a b
+      go freeA = case freeA of
+          Pure f     -> arr f
+          Seq f1 f2  -> go f2 . go f1
+          Par f1 f2  -> go f1 *** go f2
+          Effect eff -> exec eff
 
 --------------------------------------------------------------------------------
 -- ArrowChoice
@@ -84,14 +125,70 @@ instance ArrowChoice (Choice eff) where
   right (Choice a) = Choice $ \f -> right (a f)
   (Choice a) ||| (Choice b) = Choice $ \f -> a f ||| b f
 
-effectChoice :: eff a b -> Choice eff a b
-effectChoice a = Choice $ \f -> f a
+instance FreeArrowLike Choice where
+  type Ctx Choice = ArrowChoice
+  effect :: eff a b -> Choice eff a b
+  effect a = Choice $ \f -> f a
 
-evalChoice :: forall eff arr a0 b0. (ArrowChoice arr)
-            => (eff ~> arr)
-            -> Choice eff a0 b0
-            -> arr a0 b0
-evalChoice f a = runChoice a f
+  eval :: forall eff arr a0 b0. (ArrowChoice arr)
+       => (eff ~> arr)
+       -> Choice eff a0 b0
+       -> arr a0 b0
+  eval f a = runChoice a f
+
+--------------------------------------------------------------------------------
+-- ErrorChoice
+--------------------------------------------------------------------------------
+
+class ArrowError ex a where
+  catch :: a e c -> a (e, ex) c -> a e c
+
+instance (Arrow (Kleisli m), Exception ex, MonadCatch m)
+  => ArrowError ex (Kleisli m) where
+    Kleisli arr1 `catch` Kleisli arr2 = Kleisli $ \x ->
+      arr1 x `Monad.Catch.catch` curry arr2 x
+
+newtype ErrorChoice ex eff a b = ErrorChoice {
+  runErrorChoice :: forall ac. (ArrowChoice ac, ArrowError ex ac)
+                 => (eff ~> ac) -> ac a b
+}
+
+instance Category (ErrorChoice ex eff) where
+  id = ErrorChoice $ const id
+  ErrorChoice f . ErrorChoice g = ErrorChoice $ \x -> f x . g x
+
+instance Arrow (ErrorChoice ex eff) where
+  arr a = ErrorChoice $ const $ arr a
+  first (ErrorChoice a) = ErrorChoice $ \f -> first (a f)
+  second (ErrorChoice a) = ErrorChoice $ \f -> second (a f)
+  (ErrorChoice a) *** (ErrorChoice b) = ErrorChoice $ \f -> a f *** b f
+
+instance ArrowChoice (ErrorChoice ex eff) where
+  left (ErrorChoice a) = ErrorChoice $ \f -> left (a f)
+  right (ErrorChoice a) = ErrorChoice $ \f -> right (a f)
+  (ErrorChoice a) ||| (ErrorChoice b) = ErrorChoice $ \f -> a f ||| b f
+
+instance ArrowError ex (ErrorChoice ex eff) where
+  (ErrorChoice a) `catch` (ErrorChoice h) = ErrorChoice $ \f -> a f `catch` h f
+
+instance FreeArrowLike (ErrorChoice ex) where
+  type Ctx (ErrorChoice ex) = Join ArrowChoice (ArrowError ex)
+  effect :: eff a b -> ErrorChoice ex eff a b
+  effect a = ErrorChoice $ \f -> f a
+
+  eval :: forall eff arr a0 b0. (Join ArrowChoice (ArrowError ex) arr)
+       => (eff ~> arr)
+       -> ErrorChoice ex eff a0 b0
+       -> arr a0 b0
+  eval f a = case (\x -> (mapDict weaken1 x, mapDict weaken2 x)) ctx of
+    ( Dict :: Dict (ArrowChoice arr)
+      , Dict :: Dict (ArrowError ex arr)
+      ) -> runErrorChoice a f
+
+
+--------------------------------------------------------------------------------
+-- Functions
+--------------------------------------------------------------------------------
 
 -- | Map an arrow over a list.
 mapA :: ArrowChoice a => a b c -> a [b] [c]

--- a/src/Control/FunFlow.hs
+++ b/src/Control/FunFlow.hs
@@ -12,15 +12,15 @@ import           Control.FunFlow.Diagram
 import           Data.Monoid             ((<>))
 import qualified Data.Text               as T
 
-collectNames :: Flow a b -> [T.Text]
+collectNames :: forall ex a b. Flow ex a b -> [T.Text]
 collectNames flow = collectNames' $ toDiagram flow
   where
-    collectNames' :: forall a1 b1. Diagram a1 b1 -> [T.Text]
+    collectNames' :: forall a1 b1. Diagram ex a1 b1 -> [T.Text]
     collectNames' (Node (NodeProperties lbls) _ _) = lbls
     collectNames' (Seq a b) = collectNames' a ++ collectNames' b
     collectNames' (Par a b) = collectNames' a ++ collectNames' b
     collectNames' (Fanin a b) = collectNames' a ++ collectNames' b
-
+    collectNames' (Catch a b) = collectNames' a ++ collectNames' b
 
 -- | a fresh variable supply
 newtype Freshers = Freshers { unFreshers :: [T.Text] }

--- a/src/Control/FunFlow/Base.hs
+++ b/src/Control/FunFlow/Base.hs
@@ -6,18 +6,18 @@
 
 module Control.FunFlow.Base where
 
-import           Control.Arrow
-import           Control.Category
-import           Data.ByteString  (ByteString)
+import           Control.Arrow.Free
+import           Control.Category        ((.))
+import           Control.FunFlow.Diagram
+import           Data.ByteString         (ByteString)
+import           Data.Proxy              (Proxy (..))
 import           Data.Store
-import qualified Data.Text        as T
+import qualified Data.Text               as T
 import           GHC.Generics
-import           Prelude          hiding (id, (.))
-import qualified Prelude
+import           Prelude                 hiding (id, (.))
 
-newtype MailBox = MailBox
-  { unMailBox :: T.Text
-  } deriving (Generic)
+newtype MailBox = MailBox { unMailBox :: T.Text }
+  deriving Generic
 
 -- | a general facility for sending msgs. Can be created in different ways,
 -- see e.g. `newLocalPostOffice`.
@@ -34,35 +34,22 @@ data PostOffice = PostOffice
 
 type External a b = a -> PostOffice -> MailBox -> IO ()
 
-data Flow a b where
-  Step :: Store b => (a -> IO b) -> Flow a b
-  Arr :: (a -> b) -> Flow a b
-  Name :: Store b => T.Text -> Flow a b -> Flow a b
-  Compose :: Flow a b -> Flow b c -> Flow a c
-  First :: Flow b c -> Flow (b, d) (c, d)
-  Par :: Flow b c -> Flow b' c' -> Flow (b, b') (c, c')
-  Fanin :: Flow b d -> Flow c d -> Flow (Either b c) d
-  Fold :: Flow (a, b) b -> Flow ([a], b) b
-  Catch :: Flow a b -> Flow (a, String) b -> Flow a b
-  Async :: Store b => External a b -> Flow a b
+data Flow' a b where
+  Step    :: Store b => (a -> IO b) -> Flow' a b
+  Named   :: Store b => T.Text -> (a -> b) -> Flow' a b
+  Async   :: Store b => External a b -> Flow' a b
 
-instance Category Flow where
-  id = Arr Prelude.id
-  f . g = Compose g f
+type Flow = Choice Flow'
 
-instance Arrow Flow where
-  arr f = Arr f
-  first = First
-  (***) = Par
+step :: Store b => (a -> IO b) -> Flow a b
+step = effectChoice . Step
 
-instance Functor (Flow a) where
-  fmap f flow = Compose flow (Arr f)
+named :: Store b => T.Text -> (a -> b) -> Flow a b
+named n f = effectChoice $ Named n f
 
-instance ArrowChoice Flow where
-  left f = f +++ arr id
-  right f = arr id +++ f
-  f +++ g = (f >>> arr Left) ||| (g >>> arr Right)
-  f ||| g = Fanin f g
-
-(<:) :: (Store a, Store b) => Flow a b -> T.Text -> Flow a b
-f <: nm = Name nm f
+-- | Convert a flow to a diagram, for inspection/pretty printing
+toDiagram :: Flow a b -> Diagram a b
+toDiagram flow = evalChoice toDiagram' flow where
+  toDiagram' (Named n f)  = node f [n]
+  toDiagram' _
+      = Node emptyNodeProperties (Proxy :: Proxy a1) (Proxy :: Proxy b1)

--- a/src/Control/FunFlow/Base.hs
+++ b/src/Control/FunFlow/Base.hs
@@ -39,17 +39,17 @@ data Flow' a b where
   Named   :: Store b => T.Text -> (a -> b) -> Flow' a b
   Async   :: Store b => External a b -> Flow' a b
 
-type Flow = Choice Flow'
+type Flow ex = ErrorChoice ex Flow'
 
-step :: Store b => (a -> IO b) -> Flow a b
-step = effectChoice . Step
+step :: Store b => (a -> IO b) -> Flow ex a b
+step = effect . Step
 
-named :: Store b => T.Text -> (a -> b) -> Flow a b
-named n f = effectChoice $ Named n f
+named :: Store b => T.Text -> (a -> b) -> Flow ex a b
+named n f = effect $ Named n f
 
 -- | Convert a flow to a diagram, for inspection/pretty printing
-toDiagram :: Flow a b -> Diagram a b
-toDiagram flow = evalChoice toDiagram' flow where
+toDiagram :: Flow ex a b -> Diagram ex a b
+toDiagram flow = eval toDiagram' flow where
   toDiagram' (Named n f)  = node f [n]
   toDiagram' _
       = Node emptyNodeProperties (Proxy :: Proxy a1) (Proxy :: Proxy b1)

--- a/src/Control/FunFlow/Diagram.hs
+++ b/src/Control/FunFlow/Diagram.hs
@@ -1,6 +1,8 @@
-{-# LANGUAGE GADTs               #-}
-{-# LANGUAGE InstanceSigs        #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE InstanceSigs          #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
 -- | A Diagram is a representation of an arrow with labels.
 --   No computation is actually performed by a diagram, it just carries
 --   around a description.
@@ -9,10 +11,12 @@
 module Control.FunFlow.Diagram where
 
 import           Control.Arrow
+import           Control.Arrow.Free (ArrowError (..))
 import           Control.Category
-import           Data.Proxy       (Proxy (..))
-import qualified Data.Text        as T
-import           Prelude          hiding (id, (.))
+import           Data.Proxy         (Proxy (..))
+import qualified Data.Text          as T
+import           Prelude            hiding (id, (.))
+
 
 newtype NodeProperties = NodeProperties {
   labels :: [T.Text]
@@ -21,31 +25,35 @@ newtype NodeProperties = NodeProperties {
 emptyNodeProperties :: NodeProperties
 emptyNodeProperties = NodeProperties []
 
-data Diagram a b where
+data Diagram ex a b where
   Node :: NodeProperties
        -> Proxy a
        -> Proxy b
-       -> Diagram a b
-  Seq :: Diagram a b -> Diagram b c -> Diagram a c
-  Par :: Diagram a b -> Diagram c d -> Diagram (a,c) (b,d)
-  Fanin :: Diagram a c -> Diagram b c -> Diagram (Either a b) c
+       -> Diagram ex a b
+  Seq :: Diagram ex a b -> Diagram ex b c -> Diagram ex a c
+  Par :: Diagram ex a b -> Diagram ex c d -> Diagram ex (a,c) (b,d)
+  Fanin :: Diagram ex a c -> Diagram ex b c -> Diagram ex (Either a b) c
+  Catch   :: Diagram ex a b -> Diagram ex (a,ex) b -> Diagram ex a b
 
-instance Category Diagram where
+instance Category (Diagram ex) where
   id = Node emptyNodeProperties Proxy Proxy
   (.) = flip Seq
 
-instance Arrow Diagram where
-  arr :: forall a b. (a -> b) -> Diagram a b
+instance Arrow (Diagram ex) where
+  arr :: forall a b. (a -> b) -> Diagram ex a b
   arr = const $ Node emptyNodeProperties (Proxy :: Proxy a) (Proxy :: Proxy b)
   first f = Par f id
   second f = Par id f
   (***) = Par
 
-instance ArrowChoice Diagram where
+instance ArrowChoice (Diagram ex) where
   f +++ g = (f >>> arr Left) ||| (g >>> arr Right)
   f ||| g = Fanin f g
 
+instance ArrowError ex (Diagram ex) where
+  f `catch` g = Catch f g
+
 -- | Construct a labelled node
-node :: forall a b. (a -> b) -> [T.Text] -> Diagram a b
-node _ labels = Node props (Proxy :: Proxy a) (Proxy :: Proxy b)
-  where props = NodeProperties labels
+node :: forall a b ex. (a -> b) -> [T.Text] -> (Diagram ex) a b
+node _ lbls = Node props (Proxy :: Proxy a) (Proxy :: Proxy b)
+  where props = NodeProperties lbls

--- a/src/Control/FunFlow/Diagram.hs
+++ b/src/Control/FunFlow/Diagram.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE InstanceSigs        #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+-- | A Diagram is a representation of an arrow with labels.
+--   No computation is actually performed by a diagram, it just carries
+--   around a description.
+--   We explot the fact that in 7.10,
+--   everything is typeable to label the incoming and outgoing node types.
+module Control.FunFlow.Diagram where
+
+import           Control.Arrow
+import           Control.Category
+import           Data.Proxy       (Proxy (..))
+import qualified Data.Text        as T
+import           Prelude          hiding (id, (.))
+
+newtype NodeProperties = NodeProperties {
+  labels :: [T.Text]
+}
+
+emptyNodeProperties :: NodeProperties
+emptyNodeProperties = NodeProperties []
+
+data Diagram a b where
+  Node :: NodeProperties
+       -> Proxy a
+       -> Proxy b
+       -> Diagram a b
+  Seq :: Diagram a b -> Diagram b c -> Diagram a c
+  Par :: Diagram a b -> Diagram c d -> Diagram (a,c) (b,d)
+  Fanin :: Diagram a c -> Diagram b c -> Diagram (Either a b) c
+
+instance Category Diagram where
+  id = Node emptyNodeProperties Proxy Proxy
+  (.) = flip Seq
+
+instance Arrow Diagram where
+  arr :: forall a b. (a -> b) -> Diagram a b
+  arr = const $ Node emptyNodeProperties (Proxy :: Proxy a) (Proxy :: Proxy b)
+  first f = Par f id
+  second f = Par id f
+  (***) = Par
+
+instance ArrowChoice Diagram where
+  f +++ g = (f >>> arr Left) ||| (g >>> arr Right)
+  f ||| g = Fanin f g
+
+-- | Construct a labelled node
+node :: forall a b. (a -> b) -> [T.Text] -> Diagram a b
+node _ labels = Node props (Proxy :: Proxy a) (Proxy :: Proxy b)
+  where props = NodeProperties labels

--- a/src/Control/FunFlow/Exec/Local.hs
+++ b/src/Control/FunFlow/Exec/Local.hs
@@ -13,6 +13,7 @@ import           Control.Arrow.Free
 import           Control.Exception
 import           Control.FunFlow
 import           Control.FunFlow.Base
+import           Control.Monad.Catch        (Exception, MonadCatch, MonadThrow)
 import           Control.Monad.Except
 import           Control.Monad.State.Strict
 import           Data.ByteString            (ByteString)
@@ -24,19 +25,20 @@ import qualified Data.Text                  as T
 
 type PureCtx = M.Map T.Text ByteString
 
-newtype LFlowM a = LFLowM { runLFlowM :: ExceptT String (StateT FlowST IO) a }
-  deriving (Monad, Applicative, Functor, MonadIO, MonadState FlowST, MonadError String)
+newtype LFlowM ex a = LFLowM { runLFlowM :: ExceptT ex (StateT FlowST IO) a }
+  deriving ( Monad, Applicative, Functor, MonadIO, MonadState FlowST
+            , MonadThrow, MonadCatch)
 
 type FlowST = (Freshers, PureCtx)
 
-fresh :: LFlowM T.Text
+fresh :: LFlowM ex T.Text
 fresh = do
   (fs, ctx) <- get
   let (f,nfs) = popFreshers fs
   put (nfs, ctx)
   return f
 
-lookupSym :: Store a => T.Text -> LFlowM (Maybe a)
+lookupSym :: Store a => T.Text -> LFlowM ex (Maybe a)
 lookupSym k = do
   (_, ctx) <- get
   case M.lookup k ctx of
@@ -45,22 +47,23 @@ lookupSym k = do
                 Right y -> return $ Just y
                 Left _  -> return Nothing
 
-putSym :: Store a => T.Text -> a -> LFlowM ()
+putSym :: Store a => T.Text -> a -> LFlowM ex ()
 putSym k x = do
   (fs, ctx) <- get
   put $ (fs, M.insert k (encode x) ctx)
 
 
-runTillDone :: Flow a b -> a -> IO b
+runTillDone :: Exception ex => Flow ex a b -> a -> IO b
 runTillDone f x = go M.empty where
   go st0 = do
     ey <- resumeFlow f x st0
     case ey of
       Right y -> return y
-      Left (err, st1) -> do putStrLn $ "Flow failed with "++err
+      Left (err, st1) -> do putStrLn $ "Flow failed with "++ show err
                             go st1
 
-resumeFlow :: forall a b. Flow a b -> a -> PureCtx -> IO (Either (String, PureCtx) b)
+resumeFlow :: forall ex a b. Exception ex
+           => Flow ex a b -> a -> PureCtx -> IO (Either (ex, PureCtx) b)
 resumeFlow f ini ctx = do
   (eres, st) <- runStateT (runExceptT $ runLFlowM $ proceedFlow f ini) (initFreshers, ctx)
   case eres of
@@ -68,12 +71,12 @@ resumeFlow f ini ctx = do
     Right res -> return $ Right res
 
 
-puttingSym :: Store a => T.Text -> a -> LFlowM a
+puttingSym :: Store a => T.Text -> a -> LFlowM ex a
 puttingSym n x = putSym n x >> return x
 
 
-proceedFlow :: Flow a b -> a -> LFlowM b
-proceedFlow flow input = runKleisli (evalChoice proceedFlow' flow) input
+proceedFlow :: Exception ex => Flow ex a b -> a -> LFlowM ex b
+proceedFlow flow input = runKleisli (eval proceedFlow' flow) input
   where
     proceedFlow' (Named n' f) = Kleisli $ \x -> do
       n <- (n'<>) <$> fresh
@@ -88,8 +91,8 @@ proceedFlow flow input = runKleisli (evalChoice proceedFlow' flow) input
         Just y -> return y
         Nothing -> do
           ey <- liftIO $ fmap Right (f x)
-                           `catch`
-                             (\e -> return $ Left (show (e::SomeException)))
+                           `Control.Exception.catch`
+                             (\e -> return $ Left (e::SomeException))
           case ey of
             Right y  -> puttingSym n y
-            Left err -> throwError err
+            Left err -> throw err

--- a/src/Control/FunFlow/Exec/Local.hs
+++ b/src/Control/FunFlow/Exec/Local.hs
@@ -1,18 +1,25 @@
-{-# LANGUAGE Arrows, GADTs, OverloadedStrings, TupleSections,
-             TypeFamilies, GeneralizedNewtypeDeriving, ScopedTypeVariables #-}
+{-# LANGUAGE Arrows                     #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TupleSections              #-}
+{-# LANGUAGE TypeFamilies               #-}
 
 module Control.FunFlow.Exec.Local where
 
-import Control.FunFlow.Base
-import Control.FunFlow
-import Data.Store
-import qualified Data.Map.Strict as M
-import qualified Data.Text as T
-import Control.Monad.State.Strict
-import Data.ByteString (ByteString)
-import Control.Monad.Except
-import Control.Exception
-import Data.Monoid ((<>))
+import           Control.Arrow
+import           Control.Arrow.Free
+import           Control.Exception
+import           Control.FunFlow
+import           Control.FunFlow.Base
+import           Control.Monad.Except
+import           Control.Monad.State.Strict
+import           Data.ByteString            (ByteString)
+import qualified Data.Map.Strict            as M
+import           Data.Monoid                ((<>))
+import           Data.Store
+import qualified Data.Text                  as T
 
 
 type PureCtx = M.Map T.Text ByteString
@@ -36,7 +43,7 @@ lookupSym k = do
     Nothing -> return Nothing
     Just yv -> case decode yv of
                 Right y -> return $ Just y
-                Left _ -> return Nothing
+                Left _  -> return Nothing
 
 putSym :: Store a => T.Text -> a -> LFlowM ()
 putSym k x = do
@@ -57,7 +64,7 @@ resumeFlow :: forall a b. Flow a b -> a -> PureCtx -> IO (Either (String, PureCt
 resumeFlow f ini ctx = do
   (eres, st) <- runStateT (runExceptT $ runLFlowM $ proceedFlow f ini) (initFreshers, ctx)
   case eres of
-    Left err ->  return $ Left (err, snd st)
+    Left err  ->  return $ Left (err, snd st)
     Right res -> return $ Right res
 
 
@@ -66,45 +73,23 @@ puttingSym n x = putSym n x >> return x
 
 
 proceedFlow :: Flow a b -> a -> LFlowM b
-proceedFlow (Name n' f) x = do
-  n <- (n'<>) <$> fresh
-  mv <- lookupSym n
-  case mv of
-    Just y -> return y
-    Nothing -> puttingSym n =<< proceedFlow f x
-
-proceedFlow (Step f) x = do
-  n <- fresh
-  mv <- lookupSym n
-  case mv of
-    Just y -> return y
-    Nothing -> do
-      ey <- liftIO $ fmap Right (f x)
-                       `catch`
-                         (\e -> return $ Left (show (e::SomeException)))
-      case ey of
-        Right y -> puttingSym n y
-        Left err -> throwError err
-proceedFlow (Arr f) x = return $ f x
-proceedFlow (Compose f g) x = do
-  y <- proceedFlow f x
-  proceedFlow g y
-proceedFlow (Par f g) (x,y) = do
-  liftM2 (,) (proceedFlow f x) (proceedFlow g y)
-proceedFlow (First f) (x,d) = do
-  ey <- proceedFlow f x
-  return $ (ey,d)
-proceedFlow (Fanin f _) (Left x) = do
-  proceedFlow f x
-proceedFlow (Fanin _ g) (Right x) = do
-  proceedFlow g x
-proceedFlow (Fold fstep) (lst,acc) = go lst acc where
-  go [] y = return y
-  go (x:xs) y0 = do
-      y1 <- proceedFlow fstep (x,y0)
-      go xs y1
-proceedFlow (Catch f h) x = do
-  st <- get
-  proceedFlow f x `catchError` (\err -> do
-    put st
-    proceedFlow h (x,err))
+proceedFlow flow input = runKleisli (evalChoice proceedFlow' flow) input
+  where
+    proceedFlow' (Named n' f) = Kleisli $ \x -> do
+      n <- (n'<>) <$> fresh
+      mv <- lookupSym n
+      case mv of
+        Just y  -> return y
+        Nothing -> puttingSym n =<< return (f x)
+    proceedFlow' (Step f) = Kleisli $ \x -> do
+      n <- fresh
+      mv <- lookupSym n
+      case mv of
+        Just y -> return y
+        Nothing -> do
+          ey <- liftIO $ fmap Right (f x)
+                           `catch`
+                             (\e -> return $ Left (show (e::SomeException)))
+          case ey of
+            Right y  -> puttingSym n y
+            Left err -> throwError err

--- a/src/Control/FunFlow/Exec/Simple.hs
+++ b/src/Control/FunFlow/Exec/Simple.hs
@@ -1,16 +1,19 @@
-{-# LANGUAGE Arrows, GADTs, OverloadedStrings, DeriveGeneric, ScopedTypeVariables #-}
+{-# LANGUAGE Arrows              #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Control.FunFlow.Exec.Simple where
 
-import qualified Data.Text as T
-import Control.Exception (SomeException, catch)
-import Data.IORef
-import qualified Data.Map.Strict as Map
-import qualified Data.ByteString as BS
-import Control.Concurrent.MVar
-import Data.Store
-import Control.FunFlow.Base
-import Data.Unique
+import           Control.Concurrent.MVar
+import           Control.FunFlow.Base
+import qualified Data.ByteString         as BS
+import           Data.IORef
+import qualified Data.Map.Strict         as Map
+import           Data.Store
+import qualified Data.Text               as T
+import           Data.Unique
 
 newLocalPostOffice :: IO PostOffice
 newLocalPostOffice = do
@@ -45,35 +48,13 @@ newLocalPostOffice = do
     }
 
 -- | Simple evaulation of a flow
-runFlow :: Flow a b -> a -> IO b
+runFlow :: Flow' a b -> a -> IO b
 runFlow f' x' = do po <- newLocalPostOffice
                    runFlow' po f' x'
   where
-    runFlow' :: PostOffice -> Flow a b -> a -> IO b
+    runFlow' :: PostOffice -> Flow' a b -> a -> IO b
     runFlow' _ (Step f) x = f x
-    runFlow' po (Name _ f) x = runFlow' po f x
-    runFlow' po (Compose f g) x = do
-      y <- runFlow' po f x
-      runFlow' po g y
-    runFlow' po (First f) (x,d) = do
-      y <- runFlow' po f x
-      return (y,d)
-    runFlow' _ (Arr f) x = return $ f x
-    runFlow' po (Par f g) (x,y) = do
-      w <- runFlow' po f x
-      z <- runFlow' po g y
-      return (w,z)
-    runFlow' po (Fanin f _) (Left x) =
-      runFlow' po f x
-    runFlow' po (Fanin _ g) (Right x) =
-      runFlow' po g x
-    runFlow' po (Fold fstep) (lst, acc) = go lst acc where
-      go [] y = return y
-      go (x:xs) y0 = do
-          y1 <- runFlow' po fstep (x,y0)
-          go xs y1
-    runFlow' po (Catch f h) x =
-      runFlow' po f x `catch` (\e -> runFlow' po h (x,show (e::SomeException)))
+    runFlow' _ (Named _ f) x = return $ f x
     runFlow' po (Async ext) x = do
       mbox <- reserveMailBox po
       ext x po mbox

--- a/src/Control/FunFlow/Pretty.hs
+++ b/src/Control/FunFlow/Pretty.hs
@@ -10,14 +10,15 @@ import           Control.FunFlow.Diagram
 import qualified Data.Text               as T
 import           Text.PrettyPrint
 
-ppFlow :: Flow a b -> Doc
+ppFlow :: Flow ex a b -> Doc
 ppFlow = ppDiagram . toDiagram where
-  ppDiagram :: forall a b. Diagram a b -> Doc
+  ppDiagram :: forall ex a b. Diagram ex a b -> Doc
   ppDiagram (Node (NodeProperties (lbl:_)) _ _)    = text . T.unpack $ lbl
   ppDiagram (Node _ _ _)    = text "unlabeled step"
   ppDiagram (Seq f g) = parens $ ppDiagram f <+> text ">>>" <+> ppDiagram g
   ppDiagram (Par f g) = parens $ ppDiagram f <+>  text "***" <+> ppDiagram g
   ppDiagram (Fanin f g) = parens $ ppDiagram f <+>  text "|||" <+> ppDiagram g
+  ppDiagram (Catch f g) = parens $ ppDiagram f <+>  text "catch" <+> ppDiagram g
 
-showFlow :: Flow a b -> String
+showFlow :: Flow ex a b -> String
 showFlow = render . ppFlow

--- a/src/Control/FunFlow/Steps.hs
+++ b/src/Control/FunFlow/Steps.hs
@@ -1,45 +1,48 @@
-{-# LANGUAGE Arrows            #-}
-{-# LANGUAGE GADTs             #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TupleSections     #-}
+{-# LANGUAGE Arrows              #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
 
 module Control.FunFlow.Steps where
 
 import           Control.Arrow
-import           Control.Exception    (catch)
+import           Control.Arrow.Free   (catch)
+import           Control.Exception    (Exception, throw)
 import           Control.FunFlow.Base
 import           Data.Store
 import           GHC.Conc             (threadDelay)
 import           System.Random
 
-promptFor :: Read a => Flow String a
+promptFor :: Read a => Flow ex String a
 promptFor = proc s -> do
      () <- step putStr -< (s++"> ")
      s' <- step (const getLine) -< ()
      returnA -< read s'
 
-printS :: Show a => Flow a ()
-printS = Step $ \s-> print s
+printS :: Show a => Flow ex a ()
+printS = step $ \s-> print s
 
-worstBernoulli :: Flow Double Double
-worstBernoulli = step $ \p -> do
+worstBernoulli :: Exception ex => (String -> ex) -> Flow ex Double Double
+worstBernoulli errorC = step $ \p -> do
   r <- randomRIO (0,1)
   if r < p
     then return r
-    else error $ "worstBernoulli fail with "++ show r++ " > "++show p
+    else throw . errorC $ "worstBernoulli fail with "++ show r++ " > "++show p
 
--- -- | pause for a given number of seconds. Thread through a value to ensure
--- --   delay does not happen inparallel with other processing
--- pauseWith :: Store a => Flow (Int, a) a
--- pauseWith = step $ \(secs,a) -> do
---   threadDelay (secs*1000000)
---   return a
+-- | pause for a given number of seconds. Thread through a value to ensure
+--   delay does not happen inparallel with other processing
+pauseWith :: Store a => Flow ex (Int, a) a
+pauseWith = step $ \(secs,a) -> do
+  threadDelay (secs*1000000)
+  return a
 
--- -- | `retry n s f` reruns `f` on failure at most n times with a delay of `s` seconds
--- -- between retries
--- retry :: (Store a) => Int -> Int -> Flow a b -> Flow a b
--- retry 0 _ f = f
--- retry n secs f = catch f $ proc (x,_) -> do
---   x1 <- pauseWith -< (secs,x)
---   x2 <- retry (n-1) secs f -< x1
---   returnA -< x2
+-- | `retry n s f` reruns `f` on failure at most n times with a delay of `s`
+--   seconds between retries
+retry :: forall ex a b. (Exception ex, Store a)
+      => Int -> Int -> Flow ex a b -> Flow ex a b
+retry 0 _ f = f
+retry n secs f = catch f $ proc (x, (_ :: ex)) -> do
+  x1 <- pauseWith -< (secs,x)
+  x2 <- retry (n-1) secs f -< x1
+  returnA -< x2

--- a/src/Control/FunFlow/Steps.hs
+++ b/src/Control/FunFlow/Steps.hs
@@ -1,53 +1,45 @@
-{-# LANGUAGE Arrows, GADTs, OverloadedStrings, TupleSections #-}
+{-# LANGUAGE Arrows            #-}
+{-# LANGUAGE GADTs             #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections     #-}
 
 module Control.FunFlow.Steps where
 
-import Control.FunFlow.Base
-import Control.Arrow
-import System.Random
-import GHC.Conc (threadDelay)
-import Data.Store
+import           Control.Arrow
+import           Control.Exception    (catch)
+import           Control.FunFlow.Base
+import           Data.Store
+import           GHC.Conc             (threadDelay)
+import           System.Random
 
 promptFor :: Read a => Flow String a
 promptFor = proc s -> do
-     () <- Step putStr -< (s++"> ")
-     s' <- Step (const getLine) -< ()
+     () <- step putStr -< (s++"> ")
+     s' <- step (const getLine) -< ()
      returnA -< read s'
 
 printS :: Show a => Flow a ()
 printS = Step $ \s-> print s
 
 worstBernoulli :: Flow Double Double
-worstBernoulli = Step $ \p -> do
+worstBernoulli = step $ \p -> do
   r <- randomRIO (0,1)
   if r < p
     then return r
     else error $ "worstBernoulli fail with "++ show r++ " > "++show p
 
+-- -- | pause for a given number of seconds. Thread through a value to ensure
+-- --   delay does not happen inparallel with other processing
+-- pauseWith :: Store a => Flow (Int, a) a
+-- pauseWith = step $ \(secs,a) -> do
+--   threadDelay (secs*1000000)
+--   return a
 
--- | pause for a given number of seconds. Thread through a value to ensure
---   delay does not happen inparallel with other processing
-pauseWith :: Store a => Flow (Int, a) a
-pauseWith = Step $ \(secs,a) -> do
-  threadDelay (secs*1000000)
-  return a
-
--- | Map a Flow over a list
-mapF :: Flow a b -> Flow [a] [b]
-mapF f = (,[]) ^>> (Fold $ proc (x,ys) -> do
-      y <- f -< x
-      returnA -< y:ys) >>> arr reverse
--- | Filter a list
-filterF :: Flow a Bool -> Flow [a] [a]
-filterF f = (,[]) ^>> (Fold $ proc (x,ys) -> do
-      b <- f -< x
-      returnA -< if b then x:ys else ys) >>> arr reverse
-
--- | `retry n s f` reruns `f` on failure at most n times with a delay of `s` seconds
--- between retries
-retry :: (Store a) => Int -> Int -> Flow a b -> Flow a b
-retry 0 _ f = f
-retry n secs f = Catch f $ proc (x,_) -> do
-  x1 <- pauseWith -< (secs,x)
-  x2 <- retry (n-1) secs f -< x1
-  returnA -< x2
+-- -- | `retry n s f` reruns `f` on failure at most n times with a delay of `s` seconds
+-- -- between retries
+-- retry :: (Store a) => Int -> Int -> Flow a b -> Flow a b
+-- retry 0 _ f = f
+-- retry n secs f = catch f $ proc (x,_) -> do
+--   x1 <- pauseWith -< (secs,x)
+--   x2 <- retry (n-1) secs f -< x1
+--   returnA -< x2


### PR DESCRIPTION
As a consequence to this, we cannot perform the introspection on
the `Flow` type which was used to build e.g. the pretty printer. To
deal with this, we introduce the `Diagram` type, which is a 'static'
representation to which we can compile a `Flow` and use for presentation
purposes.

A couple of things have been "lost" as part of this change:

- `Name` is now `Named` and may only name pure computations, not
  arbitrary flows.
- `Catch` has gone. Like `Named`, this involves non-arrow based
  composition at the term level. I think if we were to bring it back,
  we should do so by adding it to the core arrow structure, as in e.g.
  https://hackage.haskell.org/package/arrows-0.4.4.1/docs/Control-Arrow-Operations.html