### PR TITLE
Implement content hash addressed store

### DIFF
--- a/funflow.cabal
+++ b/funflow.cabal
@@ -30,6 +30,7 @@ Library
                      Control.FunFlow
                    , Control.FunFlow.Base
                    , Control.FunFlow.ContentHashable
+                   , Control.FunFlow.ContentStore
                    , Control.FunFlow.External
                    , Control.FunFlow.External.Coordinator
                    , Control.FunFlow.External.Coordinator.Memory
@@ -60,6 +61,7 @@ Library
                , pretty
                , bytestring
                , hedis
+               , unix
 
 Test-suite test-funflow
   type:       exitcode-stdio-1.0
@@ -68,3 +70,20 @@ Test-suite test-funflow
   main-is: TestFunflow.hs
   build-depends:       base >=4.6 && <5
                      , funflow
+
+Test-suite unit-tests
+  type:               exitcode-stdio-1.0
+  default-language:   Haskell2010
+  hs-source-dirs:     test
+  main-is:            Test.hs
+  other-modules:      FunFlow.ContentStore
+  ghc-options:        -Wall
+  build-depends:      base
+                    , containers
+                    , directory
+                    , filepath
+                    , funflow
+                    , safe-exceptions
+                    , tasty
+                    , tasty-hunit
+                    , temporary

--- a/src/Control/FunFlow/ContentStore.hs
+++ b/src/Control/FunFlow/ContentStore.hs
@@ -1,0 +1,289 @@
+{-# LANGUAGE LambdaCase      #-}
+{-# LANGUAGE NamedFieldPuns  #-}
+{-# LANGUAGE RecordWildCards #-}
+
+
+-- | Hash addressed store in file system.
+--
+-- A store associates a 'Control.FunFlow.ContentHashable.ContentHash'
+-- with a directory subtree. A subtree can be either
+-- 'Control.FunFlow.ContentStore.Missing',
+-- 'Control.FunFlow.ContentStore.UnderConstruction', or
+-- 'Control.FunFlow.ContentStore.Complete'.
+-- The state of subtrees is persisted on the file system.
+--
+-- The store is thread-safe, but may not be controlled by multiple processes
+-- at the same time.
+--
+-- It is assumed that the user that the process is running under is the owner
+-- of the store root, or has permission to create it if missing.
+--
+-- It is assumed that the store root and its immediate contents are not modified
+-- externally. The contents of subtrees may be modified externally while the
+-- subtree is marked as under construction.
+--
+-- __Implementation note:__
+--
+-- Two file-system features are used to persist the state of a subtree,
+-- namely whether it exists and whether it is writable.
+--
+-- @
+--   exists   writable          state
+--   ---------------------------------------
+--                             missing
+--     X          X       under construction
+--     X                       complete
+-- @
+module Control.FunFlow.ContentStore
+  ( Status (..)
+  , StoreError (..)
+  , ContentStore
+  , root
+  , initialize
+  , allSubtrees
+  , subtrees
+  , subtreesUnderConstruction
+  , query
+  , isMissing
+  , isUnderConstruction
+  , isComplete
+  , lookup
+  , markUnderConstruction
+  , markComplete
+  , removeFailed
+  , removeForcibly
+  ) where
+
+
+import           Prelude                         hiding (lookup)
+
+import           Control.Concurrent.MVar
+import           Control.Exception               (Exception, bracket_, throwIO)
+import           Control.Monad                   (filterM)
+import           Data.Bits                       (complement)
+import           Data.List                       (foldl')
+import           Data.Maybe                      (catMaybes)
+import           Data.Typeable                   (Typeable)
+import           System.Directory                (createDirectory,
+                                                  createDirectoryIfMissing,
+                                                  doesDirectoryExist,
+                                                  listDirectory, makeAbsolute,
+                                                  removePathForcibly)
+import           System.FilePath                 ((</>))
+import           System.Posix.Files
+import           System.Posix.Types
+
+import           Control.FunFlow.ContentHashable (ContentHash, hashToPath,
+                                                  pathToHash)
+
+
+-- | Status of a subtree in the store.
+data Status
+  = Missing
+  -- ^ The subtree does not exist, yet.
+  | UnderConstruction
+  -- ^ The subtree is under construction and not ready for consumption.
+  | Complete
+  -- ^ The subtree is complete and ready for consumption.
+  deriving (Eq, Show)
+
+-- | Errors that can occur when interacting with the store.
+data StoreError
+  = NotUnderConstruction ContentHash
+  -- ^ A subtree is not under construction when it should be.
+  | AlreadyUnderConstruction ContentHash
+  -- ^ A subtree is already under construction when it should be missing.
+  | AlreadyComplete ContentHash
+  -- ^ A subtree is already complete when it shouldn't be.
+  deriving (Show, Typeable)
+instance Exception StoreError
+
+-- | A hash addressed store on the file system.
+data ContentStore = ContentStore
+  { storeRoot :: FilePath
+  -- ^ Subtrees are stored directly under this directory.
+  , storeLock :: MVar ()
+  -- ^ One global lock to ensure thread safety.
+  --
+  -- XXX: Could be replaced by a file-locks per subtree
+  --      if it becomes a bottleneck.
+  }
+
+-- | The root directory of the store.
+root :: ContentStore -> FilePath
+root = storeRoot
+
+-- | @initialize root@ initializes a store under the given root directory.
+--
+-- The root directory is created if necessary.
+--
+-- It is not safe to have multiple store objects
+-- refer to the same root directory.
+initialize :: FilePath -> IO ContentStore
+initialize root' = do
+  storeRoot <- makeAbsolute root'
+  createDirectoryIfMissing True storeRoot
+  setFileMode storeRoot readOnlyRootDirMode
+  storeLock <- newMVar ()
+  return ContentStore {..}
+
+-- | List all subtrees that are complete or under construction.
+allSubtrees :: ContentStore -> IO [ContentHash]
+allSubtrees ContentStore {storeRoot} =
+  catMaybes . map pathToHash <$> listDirectory storeRoot
+
+-- | List all complete subtrees.
+subtrees :: ContentStore -> IO [ContentHash]
+subtrees store = filterM (isComplete store) =<< allSubtrees store
+
+-- | List all subtrees under construction.
+subtreesUnderConstruction :: ContentStore -> IO [ContentHash]
+subtreesUnderConstruction store =
+  filterM (isUnderConstruction store) =<< allSubtrees store
+
+-- | Query for the state of a subtree.
+query :: ContentStore -> ContentHash -> IO Status
+query store hash = withStoreLock store $
+  internalQuery store hash
+
+isMissing :: ContentStore -> ContentHash -> IO Bool
+isMissing store hash = (== Missing) <$> query store hash
+
+isUnderConstruction :: ContentStore -> ContentHash -> IO Bool
+isUnderConstruction store hash = (== UnderConstruction) <$> query store hash
+
+isComplete :: ContentStore -> ContentHash -> IO Bool
+isComplete store hash = (== Complete) <$> query store hash
+
+-- | Get the file-path of a subtree if it is complete.
+lookup :: ContentStore -> ContentHash -> IO (Maybe FilePath)
+lookup store hash = withStoreLock store $
+  internalQuery store hash >>= \case
+    Missing -> return Nothing
+    UnderConstruction -> return Nothing
+    Complete -> return $ Just (toStorePath store hash)
+
+-- | Mark a non-existent subtree as under construction.
+--
+-- Creates the destination directory and returns its path.
+markUnderConstruction :: ContentStore -> ContentHash -> IO FilePath
+markUnderConstruction store hash = withStoreLock store $
+  internalQuery store hash >>= \case
+    Complete -> throwIO (AlreadyComplete hash)
+    UnderConstruction -> throwIO (AlreadyUnderConstruction hash)
+    Missing -> withWritableStore store $ do
+      let dir = toStorePath store hash
+      createDirectory dir
+      setDirWritable dir
+      return dir
+
+-- | Mark a subtree that was under construction as complete.
+markComplete :: ContentStore -> ContentHash -> IO ()
+markComplete store hash = withStoreLock store $
+  internalQuery store hash >>= \case
+    Missing -> throwIO (NotUnderConstruction hash)
+    Complete -> throwIO (AlreadyComplete hash)
+    UnderConstruction -> withWritableStore store $
+      unsetWritableRecursively (toStorePath store hash)
+
+-- | Remove a subtree that was under construction.
+--
+-- It is the callers responsibility to ensure that no other threads or processes
+-- will attempt to access the subtree afterwards.
+removeFailed :: ContentStore -> ContentHash -> IO ()
+removeFailed store hash = withStoreLock store $
+  internalQuery store hash >>= \case
+    Missing -> throwIO (NotUnderConstruction hash)
+    Complete -> throwIO (AlreadyComplete hash)
+    UnderConstruction -> withWritableStore store $
+      removePathForcibly (toStorePath store hash)
+
+-- | Remove a subtree independent of its state.
+-- Do nothing if it doesn't exist.
+--
+-- It is the callers responsibility to ensure that no other threads or processes
+-- will attempt to access the subtree afterwards.
+removeForcibly :: ContentStore -> ContentHash -> IO ()
+removeForcibly store hash = withStoreLock store $ withWritableStore store $
+  removePathForcibly (toStorePath store hash)
+
+
+----------------------------------------------------------------------
+-- Internals
+
+-- | Return the full store path to the given hash.
+toStorePath :: ContentStore -> ContentHash -> FilePath
+toStorePath ContentStore {storeRoot} hash = storeRoot </> hashToPath hash
+
+withStoreLock :: ContentStore -> IO a -> IO a
+withStoreLock store action = withMVar (storeLock store) $ \() -> action
+
+-- | Query the state of a subtree without taking a lock.
+internalQuery :: ContentStore -> ContentHash -> IO Status
+internalQuery store hash =
+  let dir = toStorePath store hash in
+  doesDirectoryExist dir >>= \case
+    False -> return Missing
+    True -> isWritable dir >>= \case
+      False -> return Complete
+      True -> return UnderConstruction
+
+setRootDirWritable :: ContentStore -> IO ()
+setRootDirWritable ContentStore {storeRoot} =
+  setFileMode storeRoot writableRootDirMode
+
+writableRootDirMode :: FileMode
+writableRootDirMode = writableDirMode
+
+setRootDirReadOnly :: ContentStore -> IO ()
+setRootDirReadOnly ContentStore {storeRoot} =
+  setFileMode storeRoot readOnlyRootDirMode
+
+readOnlyRootDirMode :: FileMode
+readOnlyRootDirMode = writableDirMode `intersectFileModes` allButWritableMode
+
+withWritableStore :: ContentStore -> IO a -> IO a
+withWritableStore store =
+  bracket_ (setRootDirWritable store) (setRootDirReadOnly store)
+
+isWritable :: FilePath -> IO Bool
+isWritable fp = fileAccess fp False True False
+
+setDirWritable :: FilePath -> IO ()
+setDirWritable fp = setFileMode fp writableDirMode
+
+writableDirMode :: FileMode
+writableDirMode = foldl' unionFileModes nullFileMode
+  [ directoryMode, ownerModes
+  , groupReadMode, groupExecuteMode
+  , otherReadMode, otherExecuteMode
+  ]
+
+-- | Unset write permissions on the given path.
+unsetWritable :: FilePath -> IO ()
+unsetWritable fp = do
+  mode <- fileMode <$> getFileStatus fp
+  setFileMode fp $ mode `intersectFileModes` allButWritableMode
+
+allButWritableMode :: FileMode
+allButWritableMode = complement $ foldl' unionFileModes nullFileMode
+  [ownerWriteMode, groupWriteMode, otherWriteMode]
+
+-- | Unset write permissions on all items in a directory tree recursively.
+unsetWritableRecursively :: FilePath -> IO ()
+unsetWritableRecursively = mapFSTree unsetWritable unsetWritable
+
+-- | @mapFSTree fDir fFile fp@ visits every item under the path @fp@ recursively
+-- (including @fp@) and applies @fDir@ to directory paths and @fFile@ to
+-- file paths.
+--
+-- Assumes that the path exists, either as directory or as file.
+-- Symlinks are treated as files.
+mapFSTree :: (FilePath -> IO ()) -> (FilePath -> IO ()) -> FilePath -> IO ()
+mapFSTree fDir fFile fp = doesDirectoryExist fp >>= \case
+  False -> fFile fp
+  True -> do
+    fDir fp
+    entries <- listDirectory fp
+    let fps = map (fp </>) entries
+    mapM_ (mapFSTree fDir fFile) fps

--- a/src/Control/FunFlow/ContentStore.hs
+++ b/src/Control/FunFlow/ContentStore.hs
@@ -103,7 +103,8 @@ data ContentStore = ContentStore
   { storeRoot :: FilePath
   -- ^ Subtrees are stored directly under this directory.
   , storeLock :: MVar ()
-  -- ^ One global lock to ensure thread safety.
+  -- ^ One global lock on store metadata to ensure thread safety.
+  -- The lock is taken when subtree state is changed or queried.
   --
   -- XXX: Could be replaced by a file-locks per subtree
   --      if it becomes a bottleneck.

--- a/test/FunFlow/ContentStore.hs
+++ b/test/FunFlow/ContentStore.hs
@@ -1,0 +1,213 @@
+{-# LANGUAGE LambdaCase #-}
+
+module FunFlow.ContentStore
+  ( tests
+  ) where
+
+import           Control.Exception.Safe          (tryAny)
+import           Control.FunFlow.ContentHashable (contentHash)
+import           Control.FunFlow.ContentStore    (ContentStore)
+import qualified Control.FunFlow.ContentStore    as ContentStore
+import           Control.Monad                   (void)
+import qualified Data.Set                        as Set
+import           System.Directory
+import           System.FilePath                 ((</>))
+import           System.IO.Temp
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+tests :: TestTree
+tests = testGroup "Content Store"
+
+  [ testCase "initialize fresh store" $
+    withTmpDir $ \dir -> do
+      let root = dir </> "store"
+      void $ ContentStore.initialize root
+      doesDirectoryExist root
+        @? "store root exists"
+
+  , testCase "initialize existing store" $
+    withTmpDir $ \dir -> do
+      let root = dir </> "store"
+      createDirectory root
+      void $ ContentStore.initialize root
+      doesDirectoryExist root
+        @? "store root exists"
+
+  , testCase "store is not writable" $
+    withEmptyStore $ \store -> do
+      let root = ContentStore.root store
+      not . writable <$> getPermissions root
+        @? "store not writable"
+      writeFile (root </> "test") "Hello world"
+        `shouldFail` "can't create file in store"
+
+  , testCase "subtree stages" $
+    withEmptyStore $ \store -> do
+      hash <- contentHash "test"
+
+      missing <- ContentStore.query store hash
+      missing @?= ContentStore.Missing
+      nothing <- ContentStore.lookup store hash
+      nothing @?= Nothing
+
+      subtree <- ContentStore.markUnderConstruction store hash
+      let dir = subtree </> "dir"
+          item = dir </> "file"
+          expectedContent = "Hello World"
+      underConstruction <- ContentStore.query store hash
+      underConstruction @?= ContentStore.UnderConstruction
+      nothing' <- ContentStore.lookup store hash
+      nothing' @?= Nothing
+      doesDirectoryExist subtree
+        @? "subtree exists"
+      writable <$> getPermissions subtree
+        @? "subtree is writable"
+      createDirectory dir
+      writeFile item expectedContent
+      do
+        content <- readFile item
+        content @?= expectedContent
+
+      ContentStore.markComplete store hash
+      complete <- ContentStore.query store hash
+      complete @?= ContentStore.Complete
+      justSubtree <- ContentStore.lookup store hash
+      justSubtree @?= Just subtree
+      doesDirectoryExist subtree
+        @? "subtree exists"
+      not . writable <$> getPermissions subtree
+        @? "subtree is not writable"
+      not . writable <$> getPermissions item
+        @? "item is not writable"
+      createDirectory (subtree </> "another")
+        `shouldFail` "can't create folder in complete subtree"
+      writeFile item "Another message"
+        `shouldFail` "can't write to complete item"
+      do
+        content <- readFile item
+        content @?= expectedContent
+
+  , testCase "remove failed" $
+    withEmptyStore $ \store -> do
+      hash <- contentHash "test"
+      subtree <- ContentStore.markUnderConstruction store hash
+      ContentStore.removeFailed store hash
+      not <$> doesDirectoryExist subtree
+        @? "subtree was removed"
+
+  , testCase "forcibly remove" $
+    withEmptyStore $ \store -> do
+      hash <- contentHash "test"
+      subtree <- ContentStore.markUnderConstruction store hash
+
+      ContentStore.removeForcibly store hash
+      not <$> doesDirectoryExist subtree
+        @? "remove under construction"
+
+      ContentStore.removeForcibly store hash
+      not <$> doesDirectoryExist subtree
+        @? "remove missing"
+
+      subtree' <- ContentStore.markUnderConstruction store hash
+      ContentStore.markComplete store hash
+      ContentStore.removeForcibly store hash
+      not <$> doesDirectoryExist subtree'
+        @? "remove complete"
+
+  , testCase "subtree state is persisted" $
+    withTmpDir $ \dir -> do
+      let root = dir </> "store"
+      hash <- contentHash "test"
+
+      do
+        store <- ContentStore.initialize root
+        void $ ContentStore.markUnderConstruction store hash
+
+      -- Imagine the process terminates and the store is closed
+
+      do
+        store <- ContentStore.initialize root
+        underConstruction <- ContentStore.query store hash
+        underConstruction @?= ContentStore.UnderConstruction
+        ContentStore.markComplete store hash
+
+      -- Imagine the process terminates and the store is closed
+
+      do
+        store <- ContentStore.initialize root
+        complete <- ContentStore.query store hash
+        complete @?= ContentStore.Complete
+
+  , testCase "mark complete before under construction fails" $
+    withEmptyStore $ \store -> do
+      hash <- contentHash "test"
+      ContentStore.markComplete store hash
+        `shouldFail` "complete before under construction"
+
+  , testCase "mark complete after complete fails" $
+    withEmptyStore $ \store -> do
+      hash <- contentHash "test"
+      void $ ContentStore.markUnderConstruction store hash
+      ContentStore.markComplete store hash
+      ContentStore.markComplete store hash
+        `shouldFail` "complete after complete"
+
+  , testCase "mark under construction after under construction fails" $
+    withEmptyStore $ \store -> do
+      hash <- contentHash "test"
+      void $ ContentStore.markUnderConstruction store hash
+      void $ ContentStore.markUnderConstruction store hash
+        `shouldFail` "under construction after under construction"
+
+  , testCase "mark under construction after complete fails" $
+    withEmptyStore $ \store -> do
+      hash <- contentHash "test"
+      void $ ContentStore.markUnderConstruction store hash
+      ContentStore.markComplete store hash
+      void $ ContentStore.markUnderConstruction store hash
+        `shouldFail` "under construction after complete"
+
+  , testCase "remove missing fails" $
+    withEmptyStore $ \store -> do
+      hash <- contentHash "test"
+      ContentStore.removeFailed store hash
+        `shouldFail` "remove non existent"
+
+  , testCase "remove complete fails" $
+    withEmptyStore $ \store -> do
+      hash <- contentHash "test"
+      void $ ContentStore.markUnderConstruction store hash
+      ContentStore.markComplete store hash
+      ContentStore.removeFailed store hash
+        `shouldFail` "remove complete"
+
+  , testCase "list store contents" $
+    withEmptyStore $ \store -> do
+      [a, b, c, d] <- mapM contentHash ["a", "b", "c", "d"]
+      void $ mapM (ContentStore.markUnderConstruction store) [a, b, c, d]
+      mapM_ (ContentStore.markComplete store) [a, b]
+
+      all' <- ContentStore.allSubtrees store
+      Set.fromList all' @?= Set.fromList [a, b, c, d]
+      Set.size (Set.fromList all') @?= 4
+
+      complete <- ContentStore.subtrees store
+      Set.fromList complete @?= Set.fromList [a, b]
+
+      underContsruction <- ContentStore.subtreesUnderConstruction store
+      Set.fromList underContsruction @?= Set.fromList [c, d]
+
+  ]
+
+shouldFail :: IO a -> String -> IO ()
+shouldFail m msg = tryAny m >>= \case
+  Left _ -> return ()
+  Right _ -> assertFailure msg
+
+withTmpDir :: (FilePath -> IO a) -> IO a
+withTmpDir = withSystemTempDirectory "funflow-teset"
+
+withEmptyStore :: (ContentStore -> IO a) -> IO a
+withEmptyStore k = withTmpDir $ \dir ->
+  ContentStore.initialize (dir </> "store") >>= k

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -1,0 +1,10 @@
+import qualified FunFlow.ContentStore
+import Test.Tasty
+
+main :: IO ()
+main = defaultMain tests
+
+tests :: TestTree
+tests = testGroup "Unit Tests"
+  [ FunFlow.ContentStore.tests
+  ]


### PR DESCRIPTION
Exposes an interface that should be easy to use from the coordinator/executor and post offices.

- Initialize the store once using `ContentStore.initialize root`.
- Query if a content hash already exists, or is already under construction using `ContentStore.query hash`.
- Start constructing a new store item using `ContentStore.markUnderConstruction hash`.
- Indicate when an item is finished using `ContentStore.markComplete hash`.
- Remove an item if construction failed using `ContentStore.removeFailed hash`.
- The state of an item is persisted on disk and can survive process restart.

I've also added a few test cases.