### PR TITLE
Use External,ContentHashable in external execution.

### DIFF
--- a/TestFunflow.hs
+++ b/TestFunflow.hs
@@ -8,9 +8,10 @@ import           Control.FunFlow.Base
 import           Control.FunFlow.Exec.Local
 import           Control.FunFlow.Exec.Redis
 import           Control.FunFlow.Exec.Simple
+import           Control.FunFlow.External.Coordinator.Memory
 import           Control.FunFlow.Pretty
 import           Control.FunFlow.Steps
-import           Control.Monad.Catch         (Exception)
+import           Control.Monad.Catch                         (Exception)
 import           Database.Redis
 
 newtype MyEx = MyEx [Char]
@@ -38,5 +39,5 @@ main = do res <- runTillDone flow2 ()
           print res
           putStrLn $ showFlow myFlow
           putStrLn $ showFlow flow2
-          res1 <- runFlow flow3 [1..10]
-          print res1 -}
+          res1 <- runFlow MemoryCoordinator () flow3 [1..10]
+          print res1

--- a/TestFunflow.hs
+++ b/TestFunflow.hs
@@ -34,14 +34,7 @@ flow3 = mapA (arr (+1))
 allJobs = [("job1", flow2)]
 
 main :: IO ()
-main = do conn <- connect defaultConnectInfo
-          runRFlow conn $ do jid <- sparkJob "job1" ()
-                             resumeFirstJob allJobs
-                             -- js <- getJobStatus jid
-                             -- liftIO $ print js
-          return ()
-
-          {-res <- runTillDone flow2 ()
+main = do res <- runTillDone flow2 ()
           print res
           putStrLn $ showFlow myFlow
           putStrLn $ showFlow flow2

--- a/src/Control/FunFlow/Base.hs
+++ b/src/Control/FunFlow/Base.hs
@@ -7,37 +7,19 @@
 module Control.FunFlow.Base where
 
 import           Control.Arrow.Free
-import           Control.Category        ((.))
+import           Control.Category                ((.))
+import           Control.FunFlow.ContentHashable
 import           Control.FunFlow.Diagram
-import           Data.ByteString         (ByteString)
-import           Data.Proxy              (Proxy (..))
+import           Control.FunFlow.External
+import           Data.Proxy                      (Proxy (..))
 import           Data.Store
-import qualified Data.Text               as T
-import           GHC.Generics
-import           Prelude                 hiding (id, (.))
-
-newtype MailBox = MailBox { unMailBox :: T.Text }
-  deriving Generic
-
--- | a general facility for sending msgs. Can be created in different ways,
--- see e.g. `newLocalPostOffice`.
--- Some PostOffices may survive restart (e.g. backed by persistency). Of course you
--- wont get the same object but the MailBox will in that case still be
--- be routed to the right recipient. Other PostOffices will not survive process
--- restart.
-data PostOffice = PostOffice
-  { reserveMailBox :: IO MailBox -- invoked by receiver
-  , send           :: MailBox -> ByteString -> IO () -- invoked by external
-  , awaitMail      :: MailBox -> IO ByteString -- invoked by receive, blocking
-  , checkMail      :: MailBox -> IO (Maybe ByteString) -- invoked by receive, nonblocking
-  }
-
-type External a b = a -> PostOffice -> MailBox -> IO ()
+import qualified Data.Text                       as T
+import           Prelude                         hiding (id, (.))
 
 data Flow' a b where
   Step    :: Store b => (a -> IO b) -> Flow' a b
   Named   :: Store b => T.Text -> (a -> b) -> Flow' a b
-  Async   :: Store b => External a b -> Flow' a b
+  External :: ContentHashable a => (a -> ExternalTask) -> Flow' a ContentHash
 
 type Flow ex = ErrorChoice ex Flow'
 

--- a/src/Control/FunFlow/ContentHashable.hs
+++ b/src/Control/FunFlow/ContentHashable.hs
@@ -9,6 +9,8 @@
 
 module Control.FunFlow.ContentHashable
   ( ContentHash
+  , toBytes
+  , fromBytes
   , ContentHashable(..)
   , contentHashUpdate_binaryFile
   , contentHashUpdate_byteArray#
@@ -35,7 +37,7 @@ import           Crypto.Hash                   (Context, Digest, SHA256,
                                                 hashUpdate)
 import           Data.Bits                     (shiftL)
 import           Data.ByteArray                (Bytes, MemView (MemView),
-                                                allocAndFreeze)
+                                                allocAndFreeze, convert)
 import           Data.ByteArray.Encoding       (Base (Base64URLUnpadded),
                                                 convertFromBase, convertToBase)
 import qualified Data.ByteString               as BS
@@ -70,6 +72,12 @@ import           System.IO                     (IOMode (ReadMode),
 
 newtype ContentHash = ContentHash { unContentHash :: Digest SHA256 }
   deriving (Eq, Ord, Show)
+
+toBytes :: ContentHash -> BS.ByteString
+toBytes (ContentHash digest) = convert digest
+
+fromBytes :: BS.ByteString -> Maybe ContentHash
+fromBytes bs = ContentHash <$> digestFromByteString bs
 
 -- | File path appropriate encoding of a hash
 hashToPath :: ContentHash -> FilePath

--- a/src/Control/FunFlow/Exec/Redis.hs
+++ b/src/Control/FunFlow/Exec/Redis.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE Arrows                     #-}
 {-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE EmptyDataDecls             #-}
 {-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
@@ -12,29 +13,98 @@
 module Control.FunFlow.Exec.Redis where
 
 import           Control.Arrow
-import           Control.Arrow.Free              (eval)
+import           Control.Arrow.Free                   (eval)
 import           Control.Concurrent.Async.Lifted
 import           Control.Exception
 import           Control.FunFlow.Base
+import qualified Control.FunFlow.ContentHashable      as CHash
+import           Control.FunFlow.External.Coordinator
 import           Control.FunFlow.Utils
 import           Control.Monad.Base
-import           Control.Monad.Catch             hiding (catch)
+import           Control.Monad.Catch                  hiding (catch)
 import qualified Control.Monad.Catch
 import           Control.Monad.Except
+import           Control.Monad.Fix                    (fix)
 import           Control.Monad.State.Strict
 import           Control.Monad.Trans.Control
-import           Data.ByteString                 (ByteString)
-import qualified Data.ByteString.Char8           as BS8
-import           Data.Either                     (rights)
-import           Data.Maybe                      (catMaybes)
-import           Data.Monoid                     ((<>))
+import           Data.ByteString                      (ByteString)
+import qualified Data.ByteString.Char8                as BS8
+import           Data.Either                          (fromRight, rights)
+import           Data.Maybe                           (catMaybes)
+import           Data.Monoid                          ((<>))
 import           Data.Store
-import qualified Data.Text                       as T
-import qualified Data.Text.Encoding              as DTE
-import qualified Database.Redis                  as R
+import qualified Data.Text                            as T
+import qualified Data.Text.Encoding                   as DTE
+import qualified Database.Redis                       as R
 import           GHC.Conc
 import           GHC.Generics
 import           Lens.Micro.Platform
+import           System.Clock                         (fromNanoSecs)
+
+data Redis
+
+instance Coordinator Redis where
+  type Config Redis = R.Connection
+  type Hook Redis = R.Connection
+
+  -- | Create a redis connection
+  initialise = return
+
+  submitTask conn td = liftIO $ do
+      R.runRedis conn $ do
+        void $ R.rpush "jobs_queue" [encode (jid, td ^. tdSerialised)]
+        void $ R.set jid (encode $ TaskInfo Pending)
+    where
+      jid = CHash.toBytes $ td ^. tdOutput
+
+  queueSize conn = liftIO $ R.runRedis conn $ do
+    fromIntegral . Data.Either.fromRight 0 <$> R.llen "jobs_queue"
+
+  taskInfo conn chash = liftIO $ do
+    R.runRedis conn $ do
+      eoutput <- R.get $ CHash.toBytes chash
+      case eoutput of
+        Left r -> fail $ "Redis fail: " ++ show r
+        Right Nothing -> return Nothing
+        Right (Just bs) -> case decode bs of
+          Left r   -> fail $ "Decode fail: " ++ show r
+          Right ti -> return $ Just ti
+
+
+  awaitTask conn chash = liftIO . R.runRedis conn $
+    fix $ \waitGet -> do
+      emv <- R.get $ CHash.toBytes chash
+      case emv of
+        Left r -> fail $ "redis fail " ++ show r
+        Right Nothing -> do
+          liftIO $ threadDelay 500000
+          waitGet
+        Right (Just v) -> case decode v of
+          Left r                          -> fail $ "Decode fail: " ++ show r
+          Right (TaskInfo (Completed ei)) -> return $ Just ei
+          Right (TaskInfo (Failed ei _))  -> return Nothing
+          _ -> do
+            liftIO $ threadDelay 500000
+            waitGet
+
+  updateTaskStatus conn chash status = liftIO $ do
+    R.runRedis conn
+      $ void $ R.set (CHash.toBytes chash) (encode $ TaskInfo status)
+
+  popTask conn executor = liftIO . R.runRedis conn $ do
+    job <- R.brpoplpush "jobs_queue" "job_running" 1
+    case job of
+      Left r -> fail $ "redis fail " ++ show r
+      Right Nothing -> return Nothing
+      Right (Just bs) -> case decode bs of
+        Left r                          -> fail $ "Decode fail: " ++ show r
+        Right (chashbytes, serialised) ->
+          case CHash.fromBytes chashbytes of
+            Just chash -> do
+              let status = Running $ ExecutionInfo executor (fromNanoSecs 0)
+              R.set chashbytes (encode $ TaskInfo status)
+              return . Just $ TaskDescription chash serialised
+            Nothing    -> fail $ "Cannot decode content hash."
 
 type NameSpace = ByteString
 
@@ -57,27 +127,6 @@ instance MonadCatch R.Redis where
 
 type FlowST = (NameSpace, R.Connection)
 
-type JobId = Integer
-
-data JobStatus
-  = JobDone
-  | JobError
-  | JobRunning
-  | JobQueue
-  deriving (Generic, Show)
-
-data Job a = Job
-  { jobId     :: JobId
-  , taskName  :: T.Text
-  , jobStatus :: JobStatus
-  , jobError  :: Maybe String
-  , argument  :: a
-  } deriving (Generic)
-
-instance Store JobStatus
-
-instance Store a => Store (Job a)
-
 -- | Run the RFlowM monad
 runRFlow :: R.Connection -> RFlowM a -> IO (Either String a)
 runRFlow conn mx = do
@@ -91,17 +140,16 @@ redis r = do
     Left rply -> throwError $ "redis: " ++ show rply
     Right x   -> return x
 
+fresh :: RFlowM T.Text
+fresh = do
+  n <- redis $ R.incr "fffresh"
+  return $ T.pack $ show (n :: Integer)
+
 -- | Convert a key name to a redis key - using the current namespace
 nameForKey :: T.Text -> RFlowM ByteString
 nameForKey k = do
   (ns, _) <- get
   return $ ns <> "_" <> DTE.encodeUtf8 k
-
--- | Get a fresh variable name
-fresh :: RFlowM T.Text
-fresh = do
-  n <- redis $ R.incr "fffresh"
-  return $ T.pack $ show (n :: Integer)
 
 -- | Look up a value in the current namespace
 lookupSym :: Store a => T.Text -> RFlowM (Maybe a)
@@ -121,123 +169,20 @@ putSym_ k x = do
 putSym :: Store a => T.Text -> a -> RFlowM a
 putSym n x = putSym n x >> return x
 
--- | Create a `PostOffice` based on a redis database connection
-redisPostOffice :: R.Connection -> PostOffice
-redisPostOffice conn =
-  PostOffice
-  { reserveMailBox =
-      R.runRedis conn $ do
-        n <- fmap fromRight $ R.incr "pofresh"
-        return $ MailBox $ T.pack $ show (n :: Integer)
-  , send =
-      \(MailBox nm) bs ->
-        R.runRedis conn $ do void $ R.set (DTE.encodeUtf8 nm) bs
-  , checkMail =
-      \(MailBox nm) ->
-        R.runRedis conn $ do fmap fromRight $ R.get (DTE.encodeUtf8 nm)
-  , awaitMail =
-      \(MailBox nm) ->
-        R.runRedis conn $ do
-          waitGet (DTE.encodeUtf8 nm) -- temp until we do pubsub
-  }
-  where
-    waitGet :: ByteString -> R.Redis ByteString
-    waitGet k = do
-      emv <- R.get k
-      case emv of
-        Left r -> fail $ "redis fail " ++ show r
-        Right (Nothing) -> do
-          liftIO $ threadDelay 500000
-          waitGet k
-        Right (Just v) -> return v
-
--- | Create a job in the waiting queue without actually running it
-sparkJob :: Store a => T.Text -> a -> RFlowM JobId
-sparkJob nm x = do
-  jid :: JobId <- redis $ R.incr "jobfresh"
-  let job = Job jid nm JobQueue Nothing x
-  redis $ R.rpush "jobs_queue" [encode jid]
-  redis $ R.set (BS8.pack $ "job_" ++ show jid) (encode job)
-  return jid
-
--- | Get all the jobs by status
-getJobsByStatus :: Store a => JobStatus -> RFlowM [Job a]
-getJobsByStatus js = do
-  let queueNm =
-        case js of
-          JobRunning -> "jobs_running"
-          JobQueue   -> "jobs_queue"
-          JobDone    -> "jobs_done"
-          JobError   -> "jobs_error"
-  jids <- map decode <$> redis (R.lrange queueNm 0 (-1))
-  fmap catMaybes $ mapM getJobById $ rights jids
-
--- | Get a job by job ID
-getJobById :: Store a => JobId -> RFlowM (Maybe (Job a))
-getJobById jid = do
-  let jobIdNm = BS8.pack $ "job_" ++ show jid
-  mjob <- redis $ R.get jobIdNm
-  case mdecode mjob of
-    Left _    -> return Nothing
-    Right job -> return $ Just job
-
--- | Loop forever, looking for new jobs that have been put on the waiting queue, and run them.
-queueLoop ::
-     forall ex a b. (Store a, Exception ex)
-  => [(T.Text, Flow ex a b)]
-  -> RFlowM ()
-queueLoop allJobs = forever go
-  where
-    go = do
-      mkj <- redis $ R.brpoplpush "jobs_queue" "job_running" 1
-      whenRight (mdecode mkj) $ \jid -> do
-        mjob <- getJobById jid
-        whenJust mjob $ resumeJob allJobs
-
--- | Run the first job in the running queue. This is probably not so useful anymore
-resumeFirstJob ::
-     forall ex a b. (Store a, Exception ex)
-  => [(T.Text, Flow ex a b)]
-  -> RFlowM ()
-resumeFirstJob allJobs = do
-  mjid <- redis $ R.lpop "jobs_running"
-  whenRight (mdecode mjid) $ \(jid :: JobId) -> do
-    mjob <- getJobById jid
-    whenJust mjob $ resumeJob allJobs
-
--- | Resume a job
-resumeJob ::
-     forall ex a b. (Store a, Exception ex)
-  => [(T.Text, Flow ex a b)]
-  -> Job a
-  -> RFlowM ()
-resumeJob allJobs job = do
-  whenJust (lookup (taskName job) allJobs) $ \flow -> do
-    let jobIdNm = BS8.pack $ "job_" ++ show (jobId job)
-    _1 .= jobIdNm
-    finishJob job =<< catching (runJob flow (argument job))
-
--- | When a job has finished, mark it as done and put it on the done or error queues
-finishJob :: Store a => Job a -> Either String b -> RFlowM ()
-finishJob job y = do
-  let jid = jobId job
-  let jobIdNm = BS8.pack $ "job_" ++ show jid
-  let newJob =
-        case y of
-          Right _  -> job {jobStatus = JobDone}
-          Left err -> job {jobStatus = JobError, jobError = Just err}
-  redis $ R.set jobIdNm (encode newJob)
-  redis $ R.lrem "jobs_running" 1 (encode jid)
-  case y of
-    Right _ -> redis $ R.rpush "jobs_done" [encode jid]
-    Left _  -> redis $ R.rpush "jobs_error" [encode jid]
-  return ()
-
 -- | The `Flow` arrow interpreter
-runJob :: Exception ex => Flow ex a b -> a -> RFlowM b
-runJob flow input = runKleisli (eval runJob' flow) input
+runJob :: forall c ex a b. (Coordinator c, Exception ex)
+        => c
+        -> Config c
+        -> Flow ex a b
+        -> a
+        -> RFlowM b
+runJob _ cfg flow input = do
+    hook <- initialise cfg
+    runKleisli (eval (runJob' hook) flow) input
   where
-    runJob' (Step f) = Kleisli $ \x -> do
+    runJob' :: Hook c -> Flow' a1 b1
+            -> Kleisli (ExceptT String (StateT FlowST R.Redis)) a1 b1
+    runJob' _ (Step f) = Kleisli $ \x -> do
       n <- fresh
       mv <- lookupSym n
       case mv of
@@ -250,16 +195,14 @@ runJob flow input = runKleisli (eval runJob' flow) input
           case ey of
             Right y  -> putSym n y
             Left err -> throw err
-    runJob' (Named n' f) = Kleisli $ \x -> do
+    runJob' _ (Named n' f) = Kleisli $ \x -> do
       n <- (n' <>) <$> fresh
       mv <- lookupSym n
       case mv of
         Just y  -> return y
         Nothing -> putSym n $ f x
-    runJob' (Async ext) = Kleisli $ \x -> do
-      conn <- fmap snd get
-      let po = redisPostOffice conn
-      mbox <- liftIO $ reserveMailBox po
-      liftIO $ ext x po mbox
-      Right y <- decode <$> liftIO (awaitMail po mbox)
-      return y
+    runJob' po (External toTask) = Kleisli $ \x -> do
+      chash <- liftIO $ CHash.contentHash x
+      submitTask po $ TaskDescription chash (encode $ toTask x)
+      Just _ <- awaitTask po chash
+      return chash

--- a/src/Control/FunFlow/Exec/Simple.hs
+++ b/src/Control/FunFlow/Exec/Simple.hs
@@ -31,5 +31,5 @@ runFlow _ cfg flow input = do
     runFlow' po (External toTask) = Kleisli $ \x -> do
       chash <- contentHash x
       submitTask po $ TaskDescription chash (encode $ toTask x)
-      Just _ <- awaitTask po chash
+      KnownTask _ <- awaitTask po chash
       return chash

--- a/src/Control/FunFlow/Exec/Simple.hs
+++ b/src/Control/FunFlow/Exec/Simple.hs
@@ -6,61 +6,30 @@
 
 module Control.FunFlow.Exec.Simple where
 
-import           Control.Arrow           (Kleisli (..), runKleisli)
-import           Control.Arrow.Free      (eval)
-import           Control.Concurrent.MVar
+import           Control.Arrow                        (Kleisli (..), runKleisli)
+import           Control.Arrow.Free                   (eval)
 import           Control.FunFlow.Base
-import           Control.Monad.Catch     (Exception)
-import qualified Data.ByteString         as BS
-import           Data.IORef
-import qualified Data.Map.Strict         as Map
+import           Control.FunFlow.ContentHashable
+import           Control.FunFlow.External.Coordinator
+import           Control.Monad.Catch                  (Exception)
 import           Data.Store
-import qualified Data.Text               as T
-import           Data.Unique
-
-newLocalPostOffice :: IO PostOffice
-newLocalPostOffice = do
-  lpo :: IORef (Map.Map T.Text (MVar BS.ByteString))
-      <- newIORef Map.empty
-  return $ PostOffice
-    { reserveMailBox = do
-        mv <- newEmptyMVar
-        nm <- T.pack . show . hashUnique <$> newUnique
-        modifyIORef lpo $ Map.insert nm mv
-        return $ MailBox nm,
-      send = \(MailBox nm) x-> do
-        p <- readIORef lpo
-        case Map.lookup nm p of
-          Nothing -> do
-            mv <- newMVar x
-            modifyIORef lpo $ Map.insert nm mv
-          Just mv ->
-            putMVar mv x,
-      awaitMail = \(MailBox nm)-> do
-        p <- readIORef lpo
-        case Map.lookup nm p of
-          Nothing -> fail $ "no mailbox with name " ++ T.unpack nm
-          Just mv ->
-            takeMVar mv,
-      checkMail = \(MailBox nm)-> do
-        p <- readIORef lpo
-        case Map.lookup nm p of
-          Nothing -> return $ Nothing
-          Just mv ->
-            tryTakeMVar mv
-    }
 
 -- | Simple evaulation of a flow
-runFlow :: Exception ex => Flow ex a b -> a -> IO b
-runFlow flow input = do
-  po <- newLocalPostOffice
-  runKleisli (eval (runFlow' po) flow) input
+runFlow :: forall c ex a b. (Coordinator c, Exception ex)
+        => c
+        -> Config c
+        -> Flow ex a b
+        -> a
+        -> IO b
+runFlow _ cfg flow input = do
+  hook <- initialise cfg
+  runKleisli (eval (runFlow' hook) flow) input
   where
-    runFlow' :: PostOffice -> Flow' a b -> Kleisli IO a b
+    runFlow' :: Hook c -> Flow' a1 b1 -> Kleisli IO a1 b1
     runFlow' _ (Step f) = Kleisli $ \x -> f x
     runFlow' _ (Named _ f) = Kleisli $ \x -> return $ f x
-    runFlow' po (Async ext) = Kleisli $ \x -> do
-      mbox <- reserveMailBox po
-      ext x po mbox
-      Right y <- decode <$> awaitMail po mbox
-      return y
+    runFlow' po (External toTask) = Kleisli $ \x -> do
+      chash <- contentHash x
+      submitTask po $ TaskDescription chash (encode $ toTask x)
+      Just _ <- awaitTask po chash
+      return chash

--- a/src/Control/FunFlow/External.hs
+++ b/src/Control/FunFlow/External.hs
@@ -15,8 +15,3 @@ data ExternalTask = ExternalTask {
 } deriving Generic
 
 instance Store ExternalTask
-
--- | Class of things which can be turned into an external task.
-class Externalisable a where
-  toExternalTask :: a -> ExternalTask
-

--- a/src/Control/FunFlow/External/Coordinator/Memory.hs
+++ b/src/Control/FunFlow/External/Coordinator/Memory.hs
@@ -16,7 +16,7 @@ import           Data.List                            (find)
 import qualified Data.Map.Strict                      as M
 import           System.Clock                         (fromNanoSecs)
 
-data MemoryCoordinator
+data MemoryCoordinator = MemoryCoordinator
 
 data MemHook = MemHook {
     _mhTaskQueue      :: TVar [TaskDescription]

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-9.6
+resolver: nightly-2017-11-06
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
- External tasks are now defined using `External` and `ContentHashable`.
- Redis and simple executors now use 'Coordinator' to submit and
	await tasks.
- Existing machinery for using e.g. redis as a cache is unchanged.

I had to make more changes to Redis than expected, mostly due to the need to use the ContentHash as the identifier. This is required to e.g. de-dupe two jobs submitted at a similar time.