### PR TITLE
Re-introduce parallel processing

### DIFF
--- a/funflow.cabal
+++ b/funflow.cabal
@@ -27,7 +27,8 @@ Library
    default-language:  Haskell2010
 
    Exposed-modules:
-                     Control.Arrow.Free
+                     Control.Arrow.Async
+                   , Control.Arrow.Free
                    , Control.FunFlow
                    , Control.FunFlow.Base
                    , Control.FunFlow.Utils
@@ -90,6 +91,7 @@ Test-suite unit-tests
   hs-source-dirs:     test
   main-is:            Test.hs
   other-modules:      FunFlow.ContentStore
+                      Control.Arrow.Async.Tests
   ghc-options:        -Wall
   build-depends:      base
                     , containers

--- a/src/Control/Arrow/Async.hs
+++ b/src/Control/Arrow/Async.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE UndecidableInstances  #-}
+-- | Asynchronous arrows over monads with MonadBaseControl IO, using
+--   lifted-async.
+module Control.Arrow.Async where
+
+import           Control.Arrow
+import           Control.Arrow.Free              (ArrowError (..))
+import           Control.Category
+import           Control.Concurrent.Async.Lifted
+import           Control.Monad.Catch             (Exception, MonadCatch)
+import qualified Control.Monad.Catch             as Monad.Catch
+import           Control.Monad.Trans.Control     (MonadBaseControl)
+import           Prelude                         hiding (id, (.))
+
+newtype AsyncA m a b = AsyncA { runAsyncA :: a -> m b }
+
+instance Monad m => Category (AsyncA m) where
+  id = AsyncA return
+  (AsyncA f) . (AsyncA g) = AsyncA (\b -> g b >>= f)
+
+-- | @since 2.01
+instance MonadBaseControl IO m => Arrow (AsyncA m) where
+  arr f = AsyncA (return . f)
+  first (AsyncA f) = AsyncA (\ ~(b,d) -> f b >>= \c -> return (c,d))
+  second (AsyncA f) = AsyncA (\ ~(d,b) -> f b >>= \c -> return (d,c))
+  (AsyncA f) *** (AsyncA g) = AsyncA $ \ ~(a,b) -> do
+    c <- async $ f a
+    d <- async $ g b
+    waitBoth c d
+
+instance MonadBaseControl IO m => ArrowChoice (AsyncA m) where
+    left f = f +++ arr id
+    right f = arr id +++ f
+    f +++ g = (f >>> arr Left) ||| (g >>> arr Right)
+    AsyncA f ||| AsyncA g = AsyncA (either f g)
+
+instance (Exception ex, MonadBaseControl IO m, MonadCatch m)
+  => ArrowError ex (AsyncA m) where
+    AsyncA arr1 `catch` AsyncA arr2 = AsyncA $ \x ->
+      arr1 x `Monad.Catch.catch` curry arr2 x

--- a/test/Control/Arrow/Async/Tests.hs
+++ b/test/Control/Arrow/Async/Tests.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE GADTs #-}
+module Control.Arrow.Async.Tests (tests) where
+import           Control.Arrow
+import           Control.Arrow.Async
+import           Control.Arrow.Free
+import           Control.Category
+import           Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
+import           Prelude                 hiding (id, (.))
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+data Step a b where
+  Step :: (a -> IO b) -> Step a b
+
+runStep :: Step a b -> AsyncA IO a b
+runStep (Step f) = AsyncA $ \a -> f a
+
+type Flow = Free Step
+
+tests :: TestTree
+tests = testGroup "AsyncA"
+  [ testCase "parallel arrows executed in parallel" $ do
+      sem <- newEmptyMVar
+      let flow1 = effect . Step $ \() -> takeMVar sem
+          flow2 = effect . Step $ \i -> putMVar sem i
+          flow :: Flow ((), Int) (Int, ())
+          flow = flow1 *** flow2
+      (out1, out2) <- runAsyncA (eval runStep flow) ((), 3)
+      assertEqual "Should finish" ((), 3) (out2, out1)
+  ]

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -1,5 +1,6 @@
+import qualified Control.Arrow.Async.Tests
 import qualified FunFlow.ContentStore
-import Test.Tasty
+import           Test.Tasty
 
 main :: IO ()
 main = defaultMain tests
@@ -7,4 +8,5 @@ main = defaultMain tests
 tests :: TestTree
 tests = testGroup "Unit Tests"
   [ FunFlow.ContentStore.tests
+  , Control.Arrow.Async.Tests.tests
   ]


### PR DESCRIPTION
Adds async arrows over any monad with MonadBaseControl IO, using `lifted-async`.

Note that this sits atop https://github.com/tweag/funflow/pull/10, but is fundamentally independent, it just didn't seem worth rewriting twice.