### PR TITLE
Add docker tasks

### DIFF
--- a/TestFunflow.hs
+++ b/TestFunflow.hs
@@ -66,7 +66,7 @@ redisTest = let
     flow :: SimpleFlow T.Text ContentHash
     flow = external $ \t -> ExternalTask {
         _etCommand = "/run/current-system/sw/bin/echo"
-      , _etParams = [t]
+      , _etParams = [textParam t]
       , _etWriteToStdOut = True
       }
   in do

--- a/funflow.cabal
+++ b/funflow.cabal
@@ -52,6 +52,7 @@ Library
                , store
                , text
                , containers
+               , contravariant
                , cryptonite
                , directory
                , exceptions

--- a/funflow.cabal
+++ b/funflow.cabal
@@ -36,6 +36,7 @@ Library
                    , Control.FunFlow.ContentStore
                    , Control.FunFlow.Diagram
                    , Control.FunFlow.External
+                   , Control.FunFlow.External.Docker
                    , Control.FunFlow.External.Executor
                    , Control.FunFlow.External.Coordinator
                    , Control.FunFlow.External.Coordinator.Memory

--- a/src/Control/FunFlow/Base.hs
+++ b/src/Control/FunFlow/Base.hs
@@ -14,6 +14,7 @@ import           Control.Exception               (SomeException)
 import           Control.FunFlow.ContentHashable
 import           Control.FunFlow.Diagram
 import           Control.FunFlow.External
+import qualified Control.FunFlow.External.Docker as Docker
 import           Data.Proxy                      (Proxy (..))
 import           Data.Store
 import qualified Data.Text                       as T
@@ -49,6 +50,9 @@ external = effect . External
 
 wrap :: eff a b -> Flow eff ex a b
 wrap = effect . Wrapped
+
+docker :: ContentHashable a => (a -> Docker.Config) -> Flow eff ex a ContentHash
+docker f = external $ Docker.toExternal . f
 
 putInStore :: (ContentHashable a, Store a) => Flow eff ex a ContentHash
 putInStore = effect $ PutInStore

--- a/src/Control/FunFlow/ContentHashable.hs
+++ b/src/Control/FunFlow/ContentHashable.hs
@@ -262,6 +262,8 @@ instance (ContentHashable a, ContentHashable b, ContentHashable c, ContentHashab
 instance (ContentHashable a, ContentHashable b, ContentHashable c, ContentHashable d, ContentHashable e, ContentHashable f) => ContentHashable (a, b, c, d, e, f)
 instance (ContentHashable a, ContentHashable b, ContentHashable c, ContentHashable d, ContentHashable e, ContentHashable f, ContentHashable g) => ContentHashable (a, b, c, d, e, f, g)
 
+instance ContentHashable a => ContentHashable (Maybe a)
+
 instance (ContentHashable a, ContentHashable b) => ContentHashable (Either a b)
 
 

--- a/src/Control/FunFlow/ContentHashable.hs
+++ b/src/Control/FunFlow/ContentHashable.hs
@@ -177,6 +177,7 @@ contentHashUpdate_text ctx (T.Text arr off_ len_) =
       off = off_ `shiftL` 1 -- convert from 'Word16' to 'Word8'
       len = len_ `shiftL` 1 -- convert from 'Word16' to 'Word8'
 
+-- XXX: Consider hashing the corresponding store contents instead.
 instance ContentHashable ContentHash where
   contentHashUpdate ctx (ContentHash chash) = return $ hashUpdate ctx chash
 

--- a/src/Control/FunFlow/ContentHashable.hs
+++ b/src/Control/FunFlow/ContentHashable.hs
@@ -1,7 +1,10 @@
 {-# LANGUAGE DefaultSignatures    #-}
+{-# LANGUAGE DeriveGeneric        #-}
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE LambdaCase           #-}
 {-# LANGUAGE MagicHash            #-}
+{-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE TypeApplications     #-}
 {-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE TypeSynonymInstances #-}
@@ -44,8 +47,12 @@ import qualified Data.ByteString               as BS
 import           Data.ByteString.Builder.Extra (defaultChunkSize)
 import qualified Data.ByteString.Char8         as C8
 import qualified Data.ByteString.Lazy          as BSL
+import           Data.Functor.Contravariant
 import           Data.Int
 import           Data.List                     (sort)
+import           Data.Map                      (Map)
+import qualified Data.Map                      as Map
+import           Data.Store                    (Store (..), peekException)
 import qualified Data.Text                     as T
 import qualified Data.Text.Array               as TA
 import qualified Data.Text.Internal            as T
@@ -54,7 +61,7 @@ import           Data.Typeable
 import           Data.Word
 import           Foreign.Marshal.Utils         (with)
 import           Foreign.Ptr                   (castPtr)
-import           Foreign.Storable
+import           Foreign.Storable              (Storable, sizeOf)
 import           GHC.Fingerprint
 import           GHC.Generics
 import           GHC.Integer.GMP.Internals     (BigNat (..), Integer (..))
@@ -71,7 +78,14 @@ import           System.IO                     (IOMode (ReadMode),
 
 
 newtype ContentHash = ContentHash { unContentHash :: Digest SHA256 }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Generic, Show)
+
+instance Store ContentHash where
+  size = contramap toBytes size
+  peek = fromBytes <$> peek >>= \case
+    Nothing -> peekException "Store ContentHash: Illegal digest"
+    Just x -> return x
+  poke = poke . toBytes
 
 toBytes :: ContentHash -> BS.ByteString
 toBytes (ContentHash digest) = convert digest
@@ -163,6 +177,8 @@ contentHashUpdate_text ctx (T.Text arr off_ len_) =
       off = off_ `shiftL` 1 -- convert from 'Word16' to 'Word8'
       len = len_ `shiftL` 1 -- convert from 'Word16' to 'Word8'
 
+instance ContentHashable ContentHash where
+  contentHashUpdate ctx (ContentHash chash) = return $ hashUpdate ctx chash
 
 instance ContentHashable Fingerprint where
   contentHashUpdate ctx (Fingerprint a b) = flip contentHashUpdate_storable a >=> flip contentHashUpdate_storable b $ ctx
@@ -228,6 +244,12 @@ instance ContentHashable TL.Text where
   contentHashUpdate ctx s =
     flip contentHashUpdate_fingerprint s
     >=> pure . flip (TL.foldlChunks contentHashUpdate_text) s $ ctx
+
+instance (Typeable k, Typeable v, ContentHashable k, ContentHashable v)
+  => ContentHashable (Map k v) where
+  contentHashUpdate ctx m =
+    flip contentHashUpdate_fingerprint m
+    >=> flip contentHashUpdate (Map.toList m) $ ctx
 
 instance ContentHashable a => ContentHashable [a] where
   contentHashUpdate = foldM contentHashUpdate

--- a/src/Control/FunFlow/External.hs
+++ b/src/Control/FunFlow/External.hs
@@ -1,19 +1,89 @@
-{-# LANGUAGE DeriveGeneric   #-}
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TemplateHaskell            #-}
 -- | Definition of external tasks
 module Control.FunFlow.External where
 
 import           Control.FunFlow.ContentHashable (ContentHash, ContentHashable)
 import           Control.Lens.TH
+import           Data.Semigroup
 import           Data.Store                      (Store)
+import           Data.String                     (IsString (..))
 import qualified Data.Text                       as T
 import           GHC.Generics                    (Generic)
+import           System.Posix.Types              (CGid, CUid)
+
+-- | Component of a parameter
+data ParamField
+  = ParamText !T.Text
+  | ParamPath !ContentHash
+  | ParamEnv !T.Text
+  | ParamUid
+  | ParamGid
+  | ParamOut
+  deriving Generic
+
+instance ContentHashable ParamField
+instance Store ParamField
+
+-- | A parameter to an external task
+newtype Param = Param [ParamField]
+  deriving (Generic, Monoid, Semigroup)
+
+instance IsString Param where
+  fromString s = Param [ParamText (fromString s)]
+
+instance ContentHashable Param
+instance Store Param
+
+data ConvParam f = ConvParam
+  { convPath :: ContentHash -> f FilePath
+  , convEnv :: T.Text -> f T.Text
+  , convUid :: f CUid
+  , convGid :: f CGid
+  , convOut :: f FilePath
+  }
+
+paramFieldToText :: Applicative f
+  => ConvParam f -> ParamField -> f T.Text
+paramFieldToText _ (ParamText txt) = pure txt
+paramFieldToText c (ParamPath chash) = T.pack <$> convPath c chash
+paramFieldToText c (ParamEnv env) = convEnv c env
+paramFieldToText c ParamUid = T.pack . show <$> convUid c
+paramFieldToText c ParamGid = T.pack . show <$> convGid c
+paramFieldToText c ParamOut = T.pack <$> convOut c
+
+-- | Transform a parameter to text using the given converter.
+paramToText :: Applicative f
+  => ConvParam f -> Param -> f T.Text
+paramToText c (Param ps) = mconcat <$> traverse (paramFieldToText c) ps
+
+stringParam :: String -> Param
+stringParam str = Param [ParamText (T.pack str)]
+
+textParam :: T.Text -> Param
+textParam txt = Param [ParamText txt]
+
+pathParam :: ContentHash -> Param
+pathParam chash = Param [ParamPath chash]
+
+envParam :: T.Text -> Param
+envParam env = Param [ParamEnv env]
+
+uidParam :: Param
+uidParam = Param [ParamUid]
+
+gidParam :: Param
+gidParam = Param [ParamGid]
+
+outParam :: Param
+outParam = Param [ParamOut]
 
 -- | A monomorphic description of an external task. This is basically just
 --   a command which can be run.
 data ExternalTask = ExternalTask {
     _etCommand       :: T.Text
-  , _etParams        :: [T.Text]
+  , _etParams        :: [Param]
     -- | If this is set, then the process outputs on its stdout stream
     --   rather than writing to a file. In this case, output will be
     --   redirected into a file called 'out' in the output directory.

--- a/src/Control/FunFlow/External/Docker.hs
+++ b/src/Control/FunFlow/External/Docker.hs
@@ -33,7 +33,8 @@ instance ContentHashable Config
 
 toExternal :: Config -> ExternalTask
 toExternal cfg = ExternalTask
-  { _etCommand = "/run/current-system/sw/bin/docker"
+  -- XXX: Allow to configure the path to the docker executable.
+  { _etCommand = "docker"
   , _etParams =
       [ "run"
       , "--user=" <> uidParam

--- a/src/Control/FunFlow/External/Docker.hs
+++ b/src/Control/FunFlow/External/Docker.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Control.FunFlow.External.Docker where
+
+import           Control.FunFlow.ContentHashable
+import           Control.FunFlow.External
+import           Data.Map.Strict                 (Map)
+import qualified Data.Map.Strict                 as Map
+import           Data.Semigroup                  ((<>))
+import qualified Data.Text                       as T
+import           GHC.Generics                    (Generic)
+import           System.FilePath
+
+data Bind
+  -- | Single input, will get mounted to @/input@ on the image.
+  = SingleInput ContentHash
+  -- | Multiple inputs, each gets mouted into a subdirectory under
+  -- @/input@ as described by the given mapping.
+  | MultiInput (Map FilePath ContentHash)
+  deriving Generic
+
+instance ContentHashable Bind
+
+data Config = Config
+  { image :: T.Text
+  , input :: Bind
+  , command :: FilePath
+  , args :: [T.Text]
+  } deriving Generic
+
+instance ContentHashable Config
+
+toExternal :: Config -> ExternalTask
+toExternal cfg = ExternalTask
+  { _etCommand = "/run/current-system/sw/bin/docker"
+  , _etParams =
+      [ "run"
+      , "--user=" <> uidParam
+      ] ++ mounts ++
+      [ textParam (image cfg)
+      , stringParam (command cfg)
+      ] ++ map textParam (args cfg)
+  , _etWriteToStdOut = False
+  }
+  where
+    mounts = outputMount : inputMounts
+    mount src dst =
+      "--volume=" <> pathParam src <> ":" <> stringParam dst
+    outputMount = "--volume=" <> outParam <> ":/output"
+    inputMounts = case input cfg of
+      SingleInput chash -> [ mount chash "/input" ]
+      MultiInput cmap ->
+        [ mount chash ("/input" </> dest)
+        | (dest, chash) <- Map.toList cmap
+        ]

--- a/src/Control/FunFlow/External/Docker.hs
+++ b/src/Control/FunFlow/External/Docker.hs
@@ -24,6 +24,7 @@ instance ContentHashable Bind
 
 data Config = Config
   { image :: T.Text
+  , optImageID :: Maybe T.Text
   , input :: Bind
   , command :: FilePath
   , args :: [T.Text]
@@ -39,7 +40,7 @@ toExternal cfg = ExternalTask
       [ "run"
       , "--user=" <> uidParam
       ] ++ mounts ++
-      [ textParam (image cfg)
+      [ imageArg
       , stringParam (command cfg)
       ] ++ map textParam (args cfg)
   , _etWriteToStdOut = False
@@ -55,3 +56,6 @@ toExternal cfg = ExternalTask
         [ mount chash ("/input" </> dest)
         | (dest, chash) <- Map.toList cmap
         ]
+    imageArg = textParam $ case optImageID cfg of
+      Nothing -> image cfg
+      Just id' -> image cfg <> ":" <> id'


### PR DESCRIPTION
Parameters were extended to allow external tasks to depend on paths or the environment.
The runtime values of these should not affect the result and therefore do also not affect the content hash of the external tasks.

See [here](https://github.com/tweag/funflow/blob/d1b4072d7005475d0739a52bb7164167f5442bd7/TestFunflow.hs#L101-L107) for a simple example usage.