### PR TITLE
Add `ContentStore.Item` and make the store multi-process safe

### DIFF
--- a/TestFunflow.hs
+++ b/TestFunflow.hs
@@ -6,11 +6,11 @@ import           Control.Arrow
 import           Control.Arrow.Free
 import           Control.FunFlow.Base
 import           Control.FunFlow.ContentHashable             (ContentHash)
-import           Control.FunFlow.Exec.Local
 import           Control.FunFlow.Exec.Redis
 import           Control.FunFlow.Exec.Simple
 import           Control.FunFlow.External
 import           Control.FunFlow.External.Coordinator.Memory
+import           Control.FunFlow.External.Coordinator.Redis
 import           Control.FunFlow.Pretty
 import           Control.FunFlow.Steps
 import           Control.Monad.Catch                         (Exception,

--- a/src/Control/FunFlow/Base.hs
+++ b/src/Control/FunFlow/Base.hs
@@ -24,7 +24,9 @@ data Flow' eff a b where
   Step    :: Store b => (a -> IO b) -> Flow' eff a b
   Named   :: Store b => T.Text -> (a -> b) -> Flow' eff a b
   External :: ContentHashable a => (a -> ExternalTask) -> Flow' eff a ContentHash
+  -- XXX: Return 'ContentStore.Item'.
   PutInStore :: (ContentHashable a, Store a) => Flow' eff a ContentHash
+  -- XXX: Take 'ContentStore.Item'.
   GetFromStore :: (ContentHashable a, Store a) => Flow' eff ContentHash (Maybe a)
   Wrapped :: eff a b -> Flow' eff a b
 

--- a/src/Control/FunFlow/ContentHashable.hs
+++ b/src/Control/FunFlow/ContentHashable.hs
@@ -177,10 +177,6 @@ contentHashUpdate_text ctx (T.Text arr off_ len_) =
       off = off_ `shiftL` 1 -- convert from 'Word16' to 'Word8'
       len = len_ `shiftL` 1 -- convert from 'Word16' to 'Word8'
 
--- XXX: Consider hashing the corresponding store contents instead.
-instance ContentHashable ContentHash where
-  contentHashUpdate ctx (ContentHash chash) = return $ hashUpdate ctx chash
-
 instance ContentHashable Fingerprint where
   contentHashUpdate ctx (Fingerprint a b) = flip contentHashUpdate_storable a >=> flip contentHashUpdate_storable b $ ctx
 

--- a/src/Control/FunFlow/Exec/Redis.hs
+++ b/src/Control/FunFlow/Exec/Redis.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE Arrows                     #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE EmptyDataDecls             #-}

--- a/src/Control/FunFlow/Exec/Simple.hs
+++ b/src/Control/FunFlow/Exec/Simple.hs
@@ -57,14 +57,14 @@ runFlowEx _ cfg sroot runWrapped flow input = do
             file = fp </> "out"
           in do
             BS.writeFile file $ encode x
-            CS.markComplete store chash
+            _ <- CS.markComplete store chash
             return chash
     runFlow' _ store GetFromStore = Kleisli $ \chash -> do
       mfp <- CS.lookup store chash
       case mfp of
         Nothing -> return Nothing
-        Just fp -> let
-            file = fp </> "out"
+        Just item -> let
+            file = CS.itemPath item </> "out"
           in do
             bs <- BS.readFile file
             case decode bs of

--- a/src/Control/FunFlow/External.hs
+++ b/src/Control/FunFlow/External.hs
@@ -5,6 +5,7 @@
 module Control.FunFlow.External where
 
 import           Control.FunFlow.ContentHashable (ContentHash, ContentHashable)
+import qualified Control.FunFlow.ContentStore    as CS
 import           Control.Lens.TH
 import           Data.Semigroup
 import           Data.Store                      (Store)
@@ -17,7 +18,7 @@ import           System.Posix.Types              (CGid, CUid)
 data ParamField
   = ParamText !T.Text
     -- ^ Text component.
-  | ParamPath !ContentHash
+  | ParamPath !CS.Item
     -- | Reference to a path to a content store item.
   | ParamEnv !T.Text
     -- ^ Reference to an environment variable.
@@ -48,7 +49,7 @@ instance Store Param
 
 -- | Converter of path components.
 data ConvParam f = ConvParam
-  { convPath :: ContentHash -> f FilePath
+  { convPath :: CS.Item -> f FilePath
     -- ^ Resolve a reference to a content store item.
   , convEnv :: T.Text -> f T.Text
     -- ^ Resolve an environment variable.
@@ -63,7 +64,7 @@ data ConvParam f = ConvParam
 paramFieldToText :: Applicative f
   => ConvParam f -> ParamField -> f T.Text
 paramFieldToText _ (ParamText txt) = pure txt
-paramFieldToText c (ParamPath chash) = T.pack <$> convPath c chash
+paramFieldToText c (ParamPath item) = T.pack <$> convPath c item
 paramFieldToText c (ParamEnv env) = convEnv c env
 paramFieldToText c ParamUid = T.pack . show <$> convUid c
 paramFieldToText c ParamGid = T.pack . show <$> convGid c
@@ -81,8 +82,8 @@ textParam :: T.Text -> Param
 textParam txt = Param [ParamText txt]
 
 -- | Reference to a path to a content store item.
-pathParam :: ContentHash -> Param
-pathParam chash = Param [ParamPath chash]
+pathParam :: CS.Item -> Param
+pathParam item = Param [ParamPath item]
 
 -- | Reference to an environment variable.
 envParam :: T.Text -> Param

--- a/src/Control/FunFlow/External/Coordinator.hs
+++ b/src/Control/FunFlow/External/Coordinator.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData                 #-}
 {-# LANGUAGE TemplateHaskell            #-}

--- a/src/Control/FunFlow/External/Docker.hs
+++ b/src/Control/FunFlow/External/Docker.hs
@@ -4,6 +4,7 @@
 module Control.FunFlow.External.Docker where
 
 import           Control.FunFlow.ContentHashable
+import qualified Control.FunFlow.ContentStore    as CS
 import           Control.FunFlow.External
 import           Data.Map.Strict                 (Map)
 import qualified Data.Map.Strict                 as Map
@@ -14,10 +15,10 @@ import           System.FilePath
 
 data Bind
   -- | Single input, will get mounted to @/input@ on the image.
-  = SingleInput ContentHash
+  = SingleInput CS.Item
   -- | Multiple inputs, each gets mouted into a subdirectory under
   -- @/input@ as described by the given mapping.
-  | MultiInput (Map FilePath ContentHash)
+  | MultiInput (Map FilePath CS.Item)
   deriving Generic
 
 instance ContentHashable Bind

--- a/src/Control/FunFlow/External/Executor.hs
+++ b/src/Control/FunFlow/External/Executor.hs
@@ -52,7 +52,7 @@ execute store td = do
           , std_out = out
           }
         convParam = ConvParam
-          { convPath = \h -> MaybeT (CS.lookup store h)
+          { convPath = pure . CS.itemPath
           , convEnv = \e -> T.pack <$> MaybeT (getEnv $ T.unpack e)
           , convUid = liftIO $ getEffectiveUserID
           , convGid = liftIO $ getEffectiveGroupID
@@ -87,7 +87,7 @@ execute store td = do
             end <- getTime Monotonic
             case exitCode of
               ExitSuccess   -> do
-                CS.markComplete store (td ^. tdOutput)
+                _ <- CS.markComplete store (td ^. tdOutput)
                 return $ Success (diffTimeSpec start end)
               ExitFailure i -> do
                 CS.removeFailed store (td ^. tdOutput)


### PR DESCRIPTION
The `ContentHashable ContentStore.Item` instance hashes the contents of the subtree in the content store.
For now I've just left notes on `PutInStore` and `GetInStore` about using `Item` in the future.