### PR TITLE
Add watch capability to content store using inotify

### DIFF
--- a/funflow.cabal
+++ b/funflow.cabal
@@ -48,8 +48,10 @@ Library
                    , Control.FunFlow.Exec.RedisJobs
    Build-depends:
                  base                    >= 4.6 && <5
+               , async
                , clock
                , constraints
+               , hinotify
                , store
                , text
                , containers
@@ -112,6 +114,7 @@ Test-suite unit-tests
                       Control.Arrow.Async.Tests
   ghc-options:        -Wall
   build-depends:      base
+                    , async
                     , containers
                     , directory
                     , filepath


### PR DESCRIPTION
When adding this feature it turned out that I would have needed a sum type like `Instruction` for every variant of `createIfMissing`, or `lookup`. So, I've instead turned `Status` into a three-way `Either` with more meaningful constructor names.
I've also used that opportunity to rename `UnderConstruction` to `Pending` to steal less line space.