### PR TITLE
Fix potential deadlock in simple runner

### DIFF
--- a/TestFunflow.hs
+++ b/TestFunflow.hs
@@ -46,19 +46,21 @@ flow3 = mapA (arr (+1))
 allJobs = [("job1", flow2)]
 
 main :: IO ()
-main = withSystemTempDir "test_output" $ \storeDir -> do
-  memHook <- createMemoryCoordinator
-  res <- runSimpleFlow MemoryCoordinator memHook storeDir flow2 ()
-  print res
-  res' <- runSimpleFlow MemoryCoordinator memHook storeDir flow2caught ()
-  print res'
-  putStrLn $ showFlow myFlow
-  putStrLn $ showFlow flow2
-  res1 <- runSimpleFlow MemoryCoordinator memHook storeDir flow3 [1..10]
-  print res1
--- main = redisTest
-  externalTest
-  storeTest
+main =
+  withSystemTempDir "test_output" $ \storeDir ->
+  CS.withStore storeDir $ \store -> do
+    memHook <- createMemoryCoordinator
+    res <- runSimpleFlow MemoryCoordinator memHook store flow2 ()
+    print res
+    res' <- runSimpleFlow MemoryCoordinator memHook store flow2caught ()
+    print res'
+    putStrLn $ showFlow myFlow
+    putStrLn $ showFlow flow2
+    res1 <- runSimpleFlow MemoryCoordinator memHook store flow3 [1..10]
+    print res1
+--  main = redisTest
+    externalTest
+    storeTest
 
 externalTest :: IO ()
 externalTest = let
@@ -114,6 +116,7 @@ redisTest = let
       , _etParams = [textParam t]
       , _etWriteToStdOut = True
       }
-  in withSystemTempDir "test_output" $ \storeDir -> do
-    out <- runSimpleFlow Redis redisConf storeDir flow someString
-    print out
+  in withSystemTempDir "test_output" $ \storeDir ->
+    CS.withStore storeDir $ \store -> do
+      out <- runSimpleFlow Redis redisConf store flow someString
+      print out

--- a/app/FFExecutorD.hs
+++ b/app/FFExecutorD.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeOperators      #-}
 
+import qualified Control.FunFlow.ContentStore               as CS
 import           Control.FunFlow.External.Coordinator.Redis
 import           Control.FunFlow.External.Executor
 import qualified Data.ByteString                            as BS
@@ -33,4 +34,4 @@ main = do
 
   -- XXX: Improve handling of invalid paths.
   storePath' <- parseAbsDir (storePath config)
-  executeLoop Redis redisConf storePath'
+  CS.withStore storePath' $ executeLoop Redis redisConf

--- a/src/Control/FunFlow/External/Executor.hs
+++ b/src/Control/FunFlow/External/Executor.hs
@@ -104,9 +104,9 @@ execute store td = do
 executeLoop :: forall c. Coordinator c
             => c
             -> Config c
-            -> Path Abs Dir
+            -> CS.ContentStore
             -> IO ()
-executeLoop _ cfg sroot = do
+executeLoop _ cfg store = do
   handleScribe <- mkHandleScribe ColorIfTerminal stdout InfoS V2
   let mkLogEnv = registerScribe "stdout" handleScribe defaultScribeSettings =<< initLogEnv "FFExecutorD" "production"
   bracket mkLogEnv closeScribes $ \le -> do
@@ -123,7 +123,7 @@ executeLoop _ cfg sroot = do
           afterTime t = Completed $ ExecutionInfo executor t
           afterFailure t i = Failed (ExecutionInfo executor t) i
 
-      CS.withStore sroot $ \store -> forever $ do
+      forever $ do
         $(logTM) InfoS "Awaiting task from coordinator."
         mtask <- popTask hook executor
         case mtask of

--- a/test/FunFlow/TestFlows.hs
+++ b/test/FunFlow/TestFlows.hs
@@ -7,6 +7,7 @@ module FunFlow.TestFlows where
 import           Control.Arrow
 import           Control.Exception
 import           Control.FunFlow.Base
+import qualified Control.FunFlow.ContentStore                as CS
 import           Control.FunFlow.Steps
 import           Control.Monad                               (when)
 import           Path
@@ -54,11 +55,13 @@ setup = do ex <- doesFileExist [absfile|/tmp/lazarus_note|]
 
 testFlowAssertion :: FlowAssertion -> TestTree
 testFlowAssertion (FlowAssertion nm x flw expect before) =
-  testCase nm $ withSystemTempDir "test_output_" $ \store -> do
-    hook <- createMemoryCoordinator
-    before
-    res <- runSimpleFlow MemoryCoordinator hook store flw x
-    assertFlowResult expect res
+  testCase nm $
+    withSystemTempDir "test_output_" $ \storeDir ->
+    CS.withStore storeDir $ \store -> do
+      hook <- createMemoryCoordinator
+      before
+      res <- runSimpleFlow MemoryCoordinator hook store flw x
+      assertFlowResult expect res
 
 assertFlowResult :: (Eq a, Show ex, Show a) => Maybe a -> Either ex a -> Assertion
 assertFlowResult expect res =


### PR DESCRIPTION
The ContentStore uses two different synchronization mechanisms:
* MVar - for synchronization between threads within a process
* File lock - for synchronization between processes
Unfortunately, file locks only have process granularity and can not be
used for thread synchronization. Therefore, it is unsafe to have
multiple content store objects refer to the same content store within
one process.