### PR TITLE
Add content addressable store

### DIFF
--- a/src/Control/FunFlow/ContentHashable.hs
+++ b/src/Control/FunFlow/ContentHashable.hs
@@ -24,6 +24,8 @@ module Control.FunFlow.ContentHashable
   , FileContent (..)
   , DirectoryContent (..)
 
+  , encodeHash
+  , decodeHash
   , hashToPath
   , pathToHash
 
@@ -94,12 +96,24 @@ fromBytes :: BS.ByteString -> Maybe ContentHash
 fromBytes bs = ContentHash <$> digestFromByteString bs
 
 -- | File path appropriate encoding of a hash
+encodeHash :: ContentHash -> BS.ByteString
+encodeHash = convertToBase Base64URLUnpadded . toBytes
+
+-- | Inverse of 'encodeHash' if given a valid input.
+--
+-- prop> decodeHash (encodeHash x) = Just x
+decodeHash :: BS.ByteString -> Maybe ContentHash
+decodeHash bs = case convertFromBase Base64URLUnpadded bs of
+  Left _ -> Nothing
+  Right x -> fromBytes x
+
+-- | File path appropriate encoding of a hash
 hashToPath :: ContentHash -> Path.Path Path.Rel Path.Dir
-hashToPath (ContentHash h) =
-  case Path.parseRelDir $ C8.unpack $ convertToBase Base64URLUnpadded h of
+hashToPath h =
+  case Path.parseRelDir $ C8.unpack $ encodeHash h of
     Nothing -> error
-      "[ContentHashable.hashToPath]\
-      \ Failed to convert hash to directory name"
+      "[ContentHashable.hashToPath] \
+      \Failed to convert hash to directory name"
     Just dir -> dir
 
 
@@ -107,9 +121,7 @@ hashToPath (ContentHash h) =
 --
 -- prop> pathToHash (hashToPath x) = Just x
 pathToHash :: FilePath -> Maybe ContentHash
-pathToHash fp = case convertFromBase Base64URLUnpadded (C8.pack fp) of
-  Left  _ -> Nothing
-  Right x -> ContentHash <$> digestFromByteString (x :: BS.ByteString)
+pathToHash = decodeHash . C8.pack
 
 
 class ContentHashable a where

--- a/src/Control/FunFlow/ContentHashable.hs
+++ b/src/Control/FunFlow/ContentHashable.hs
@@ -14,7 +14,7 @@ module Control.FunFlow.ContentHashable
   ( ContentHash
   , toBytes
   , fromBytes
-  , ContentHashable(..)
+  , ContentHashable (..)
   , contentHashUpdate_binaryFile
   , contentHashUpdate_byteArray#
   , contentHashUpdate_fingerprint

--- a/src/Control/FunFlow/ContentStore.hs
+++ b/src/Control/FunFlow/ContentStore.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE QuasiQuotes         #-}
 {-# LANGUAGE PatternSynonyms     #-}
 {-# LANGUAGE RecordWildCards     #-}
@@ -48,9 +49,10 @@ module Control.FunFlow.ContentStore
   , open
   , close
   , withStore
-  , allSubtrees
-  , subtrees
-  , subtreesPending
+  , listAll
+  , listPending
+  , listComplete
+  , listItems
   , query
   , isMissing
   , isPending
@@ -64,6 +66,7 @@ module Control.FunFlow.ContentStore
   , markComplete
   , removeFailed
   , removeForcibly
+  , removeItemForcibly
   ) where
 
 
@@ -73,15 +76,20 @@ import           Control.Concurrent              (threadDelay)
 import           Control.Concurrent.Async
 import           Control.Concurrent.MVar
 import           Control.Exception               (Exception, bracket_, catch,
-                                                  displayException, throwIO)
-import           Control.Monad                   (filterM, forever, void)
+                                                  throwIO)
+import           Control.Lens
+import           Control.Monad                   ((<=<), (>=>), forever, void)
 import           Control.Monad.Catch             (MonadMask, bracket)
 import           Control.Monad.IO.Class          (MonadIO, liftIO)
+import           Crypto.Hash                     (hashUpdate)
 import           Data.Bits                       (complement)
-import           Data.Functor.Contravariant
-import           Data.List                       (foldl')
-import           Data.Maybe                      (mapMaybe)
+import qualified Data.ByteString.Char8           as C8
+import           Data.Foldable                   (asum)
+import           Data.List                       (foldl', stripPrefix)
+import           Data.Maybe                      (fromMaybe)
+import           Data.Monoid                     ((<>))
 import qualified Data.Store
+import           Data.String                     (IsString)
 import           Data.Typeable                   (Typeable)
 import           GHC.Generics                    (Generic)
 import           GHC.IO.Device                   (SeekMode (AbsoluteSeek))
@@ -97,7 +105,9 @@ import           System.Posix.Types
 import           Control.FunFlow.ContentHashable (ContentHash,
                                                   ContentHashable (..),
                                                   DirectoryContent (..),
-                                                  hashToPath, pathToHash)
+                                                  contentHashUpdate_fingerprint,
+                                                  encodeHash, pathToHash,
+                                                  toBytes)
 
 
 -- | Status of a subtree in the store.
@@ -128,6 +138,8 @@ data StoreError
   -- ^ A subtree is already under construction when it should be missing.
   | AlreadyComplete ContentHash
   -- ^ A subtree is already complete when it shouldn't be.
+  | CorruptedLink ContentHash FilePath
+  -- ^ The link under the given hash points to an invalid path.
   deriving (Show, Typeable)
 instance Exception StoreError
 
@@ -148,25 +160,24 @@ data ContentStore = ContentStore
   }
 
 -- | A completed item in the 'ContentStore'.
-newtype Item = Item { itemPath :: Path Abs Dir }
-  deriving (Eq, Show, Generic)
+data Item = Item { itemHash :: ContentHash }
+  deriving (Eq, Ord, Show, Generic)
 
 instance ContentHashable Item where
   contentHashUpdate ctx item =
-    contentHashUpdate ctx (DirectoryContent (itemPath item))
+    flip contentHashUpdate_fingerprint item
+    >=> pure . flip hashUpdate (toBytes $ itemHash item)
+    $ ctx
 
-instance Data.Store.Store Item where
-  size = contramap (fromAbsDir . itemPath) Data.Store.size
-  poke item = Data.Store.poke $ fromAbsDir $ itemPath item
-  peek = do
-    eDir <- parseAbsDir <$> Data.Store.peek
-    case eDir of
-      Left e -> fail $ displayException e
-      Right dir -> return $ Item dir
+instance Data.Store.Store Item
 
 -- | The root directory of the store.
 root :: ContentStore -> Path Abs Dir
 root = storeRoot
+
+-- | The store path of a completed item.
+itemPath :: ContentStore -> Item -> Path Abs Dir
+itemPath store = mkItemPath store . itemHash
 
 -- | @open root@ opens a store under the given root directory.
 --
@@ -200,26 +211,45 @@ withStore :: (MonadIO m, MonadMask m)
   => Path Abs Dir -> (ContentStore -> m a) -> m a
 withStore root' = bracket (liftIO $ open root') (liftIO . close)
 
--- | List all subtrees that are complete or under construction.
-allSubtrees :: ContentStore -> IO [ContentHash]
-allSubtrees ContentStore {storeRoot} =
-  mapMaybe conv . fst <$> listDir storeRoot
+-- | List all elements in the store
+-- @(pending keys, completed keys, completed items)@.
+listAll :: ContentStore -> IO ([ContentHash], [ContentHash], [Item])
+listAll ContentStore {storeRoot} =
+  foldr go ([], [], []) . fst <$> listDir storeRoot
   where
-    conv = pathToHash . dropTrailingPathSeparator . fromRelDir . dirname
+    go d prev@(builds, outs, items) = fromMaybe prev $ asum
+      [ parsePending d >>= \x -> Just (x:builds, outs, items)
+      , parseComplete d >>= \x -> Just (builds, x:outs, items)
+      , parseItem d >>= \x -> Just (builds, outs, x:items)
+      ]
+    parsePending :: Path Abs Dir -> Maybe ContentHash
+    parsePending = pathToHash <=< stripPrefix pendingPrefix . extractDir
+    parseComplete :: Path Abs Dir -> Maybe ContentHash
+    parseComplete = pathToHash <=< stripPrefix completePrefix . extractDir
+    parseItem :: Path Abs Dir -> Maybe Item
+    parseItem = fmap Item . pathToHash <=< stripPrefix itemPrefix . extractDir
+    extractDir :: Path Abs Dir -> FilePath
+    extractDir = dropTrailingPathSeparator . fromRelDir . dirname
 
--- | List all complete subtrees.
-subtrees :: ContentStore -> IO [ContentHash]
-subtrees store = filterM (isComplete store) =<< allSubtrees store
+-- | List all pending keys in the store.
+listPending :: ContentStore -> IO [ContentHash]
+listPending = fmap (^._1) . listAll
 
--- | List all subtrees under construction.
-subtreesPending :: ContentStore -> IO [ContentHash]
-subtreesPending store =
-  filterM (isPending store) =<< allSubtrees store
+-- | List all completed keys in the store.
+listComplete :: ContentStore -> IO [ContentHash]
+listComplete = fmap (^._2) . listAll
+
+-- | List all completed items in the store.
+listItems :: ContentStore -> IO [Item]
+listItems = fmap (^._3) . listAll
 
 -- | Query for the state of a subtree.
 query :: ContentStore -> ContentHash -> IO (Status () () ())
 query store hash = withStoreLock store $
-  internalQuery store hash
+  internalQuery store hash >>= pure . \case
+    Missing _ -> Missing ()
+    Pending _ -> Pending ()
+    Complete _ -> Complete ()
 
 isMissing :: ContentStore -> ContentHash -> IO Bool
 isMissing store hash = (== Missing ()) <$> query store hash
@@ -235,8 +265,8 @@ lookup :: ContentStore -> ContentHash -> IO (Status () () Item)
 lookup store hash = withStoreLock store $
   internalQuery store hash >>= \case
     Missing () -> return $ Missing ()
-    Pending () -> return $ Pending ()
-    Complete () -> return $ Complete (Item (storePath store hash))
+    Pending _ -> return $ Pending ()
+    Complete item -> return $ Complete item
 
 -- | Query a subtree and return it if completed.
 -- Return an 'Control.Concurrent.Async' to await updates,
@@ -246,11 +276,10 @@ lookupOrWait
   -> ContentHash
   -> IO (Status () (Async Update) Item)
 lookupOrWait store hash = withStoreLock store $
-  let dir = storePath store hash in
   internalQuery store hash >>= \case
-    Complete () -> return $ Complete (Item dir)
+    Complete item -> return $ Complete item
     Missing () -> return $ Missing ()
-    Pending () -> Pending <$> internalWatchPending store hash
+    Pending _ -> Pending <$> internalWatchPending store hash
 
 -- | Query a subtree and block, if necessary, until it is completed or failed.
 -- Returns 'Nothing' if the subtree is not in the store
@@ -272,14 +301,11 @@ constructOrWait
   -> ContentHash
   -> IO (Status (Path Abs Dir) (Async Update) Item)
 constructOrWait store hash = withStoreLock store $
-  let dir = storePath store hash in
   internalQuery store hash >>= \case
-    Complete () -> return $ Complete (Item dir)
-    Missing () -> withWritableStore store $ do
-      createDir dir
-      setDirWritable dir
-      return $ Missing dir
-    Pending () -> Pending <$> internalWatchPending store hash
+    Complete item -> return $ Complete item
+    Missing () -> withWritableStore store $
+      Missing <$> createBuildDir store hash
+    Pending _ -> Pending <$> internalWatchPending store hash
 
 -- | Atomically query the state of a subtree
 -- and mark it as under construction if missing.
@@ -288,14 +314,11 @@ constructIfMissing
   -> ContentHash
   -> IO (Status (Path Abs Dir) () Item)
 constructIfMissing store hash = withStoreLock store $
-  let dir = storePath store hash in
   internalQuery store hash >>= \case
-    Complete () -> return $ Complete (Item dir)
-    Pending () -> return $ Pending ()
-    Missing () -> withWritableStore store $ do
-      createDir dir
-      setDirWritable dir
-      return $ Missing dir
+    Complete item -> return $ Complete item
+    Pending _ -> return $ Pending ()
+    Missing () -> withWritableStore store $
+      Missing <$> createBuildDir store hash
 
 -- | Mark a non-existent subtree as under construction.
 --
@@ -305,26 +328,33 @@ constructIfMissing store hash = withStoreLock store $
 markPending :: ContentStore -> ContentHash -> IO (Path Abs Dir)
 markPending store hash = withStoreLock store $
   internalQuery store hash >>= \case
-    Complete () -> throwIO (AlreadyComplete hash)
-    Pending () -> throwIO (AlreadyPending hash)
-    Missing () -> withWritableStore store $ do
-      let dir = storePath store hash
-      createDir dir
-      setDirWritable dir
-      return dir
-
--- | Mark a subtree that was under construction as complete.
-markComplete :: ContentStore -> ContentHash -> IO Item
-markComplete store hash = withStoreLock store $
-  internalQuery store hash >>= \case
-    Missing () -> throwIO (NotPending hash)
-    Complete () -> throwIO (AlreadyComplete hash)
-    Pending () -> withWritableStore store $ do
-      let dir = storePath store hash
-      unsetWritableRecursively dir
-      return $ Item dir
+    Complete _ -> throwIO (AlreadyComplete hash)
+    Pending _ -> throwIO (AlreadyPending hash)
+    Missing () -> withWritableStore store $
+      createBuildDir store hash
 
 -- | Remove a subtree that was under construction.
+markComplete :: ContentStore -> ContentHash -> IO Item
+markComplete store inHash = withStoreLock store $
+  internalQuery store inHash >>= \case
+    Missing () -> throwIO (NotPending inHash)
+    Complete _ -> throwIO (AlreadyComplete inHash)
+    Pending build -> withWritableStore store $ do
+      unsetWritableRecursively build
+      -- XXX: Hashing large data can take some time,
+      --   could we avoid locking the store for all that time?
+      -- XXX: Take executable bit of files into account.
+      outHash <- contentHash (DirectoryContent build)
+      let out = mkItemPath store outHash
+          link' = mkCompletePath store inHash
+      doesDirExist out >>= \case
+        True -> removeDir build
+        False -> renameDir build out
+      rel <- makeRelative (parent link') out
+      let from' = dropTrailingPathSeparator $ fromAbsDir link'
+          to' = dropTrailingPathSeparator $ fromRelDir rel
+      createSymbolicLink to' from'
+      pure $! Item outHash
 --
 -- It is the callers responsibility to ensure that no other threads or processes
 -- will attempt to access the subtree afterwards.
@@ -332,9 +362,9 @@ removeFailed :: ContentStore -> ContentHash -> IO ()
 removeFailed store hash = withStoreLock store $
   internalQuery store hash >>= \case
     Missing () -> throwIO (NotPending hash)
-    Complete () -> throwIO (AlreadyComplete hash)
-    Pending () -> withWritableStore store $
-      removePathForcibly (fromAbsDir $ storePath store hash)
+    Complete _ -> throwIO (AlreadyComplete hash)
+    Pending build -> withWritableStore store $
+      removePathForcibly (fromAbsDir build)
 
 -- | Remove a subtree independent of its state.
 -- Do nothing if it doesn't exist.
@@ -343,8 +373,28 @@ removeFailed store hash = withStoreLock store $
 -- will attempt to access the subtree afterwards.
 removeForcibly :: ContentStore -> ContentHash -> IO ()
 removeForcibly store hash = withStoreLock store $ withWritableStore store $
-  removePathForcibly (fromAbsDir $ storePath store hash)
+  internalQuery store hash >>= \case
+    Missing () -> pure ()
+    Pending build -> removePathForcibly (fromAbsDir build)
+    Complete _out ->
+      removePathForcibly $
+        dropTrailingPathSeparator $ fromAbsDir $ mkCompletePath store hash
+      -- XXX: This will leave orphan store items behind.
+      --   Add GC in some form.
 
+-- | Remove a completed item in the store.
+-- Do nothing if not completed.
+--
+-- It is the callers responsibility to ensure that no other threads or processes
+-- will attempt to access the contents afterwards.
+--
+-- Note, this will leave keys pointing to that item dangling.
+-- There is no garbage collection mechanism in place at the moment.
+removeItemForcibly :: ContentStore -> Item -> IO ()
+removeItemForcibly store item = withStoreLock store $ withWritableStore store $
+  removePathForcibly (fromAbsDir $ itemPath store item)
+  -- XXX: Remove dangling links.
+  --   Add back-references in some form.
 
 ----------------------------------------------------------------------
 -- Internals
@@ -379,28 +429,72 @@ withStoreLock store action =
     withStoreFileLock store $
       action
 
--- | Return the full store path to the given hash.
-storePath :: ContentStore -> ContentHash -> Path Abs Dir
-storePath ContentStore {storeRoot} hash = storeRoot </> hashToPath hash
+prefixHashPath :: C8.ByteString -> ContentHash -> Path Rel Dir
+prefixHashPath pref hash
+  | Just dir <- Path.parseRelDir $ C8.unpack $ pref <> encodeHash hash
+  = dir
+  | otherwise = error
+      "[Control.FunFlow.ContentStore.prefixHashPath] \
+      \Failed to construct hash path."
 
--- | Query the state of a subtree without taking a lock.
-internalQuery :: ContentStore -> ContentHash -> IO (Status () () ())
-internalQuery store hash =
-  let dir = storePath store hash in
-  doesDirExist dir >>= \case
-    False -> return $ Missing ()
-    True -> isWritable dir >>= \case
-      False -> return $ Complete ()
-      True -> return $ Pending ()
+pendingPrefix, completePrefix, itemPrefix :: IsString s => s
+pendingPrefix = "pending-"
+completePrefix = "complete-"
+itemPrefix = "item-"
 
--- | Watch the given subtree under construction.
--- The returned 'Async' completes after the subtree is completed or failed.
+-- | Return the full build path for the given input hash.
+mkPendingPath :: ContentStore -> ContentHash -> Path Abs Dir
+mkPendingPath ContentStore {storeRoot} hash =
+  storeRoot </> prefixHashPath pendingPrefix hash
+
+-- | Return the full link path for the given input hash.
+mkCompletePath :: ContentStore -> ContentHash -> Path Abs Dir
+mkCompletePath ContentStore {storeRoot} hash =
+  storeRoot </> prefixHashPath completePrefix hash
+
+-- | Return the full store path to the given output hash.
+mkItemPath :: ContentStore -> ContentHash -> Path Abs Dir
+mkItemPath ContentStore {storeRoot} hash =
+  storeRoot </> prefixHashPath itemPrefix hash
+
+-- | Query the state under the given key without taking a lock.
+internalQuery
+  :: ContentStore
+  -> ContentHash
+  -> IO (Status () (Path Abs Dir) Item)
+internalQuery store inHash = do
+  let build = mkPendingPath store inHash
+      link' = mkCompletePath store inHash
+  buildExists <- doesDirExist build
+  if buildExists then
+    pure $! Pending build
+  else do
+    linkExists <- doesDirExist link'
+    if linkExists then do
+      out <- readSymbolicLink
+        (dropTrailingPathSeparator $ fromAbsDir link')
+      case pathToHash =<< stripPrefix itemPrefix out of
+        Nothing -> throwIO $ CorruptedLink inHash out
+        Just outHash -> return $ Complete (Item outHash)
+    else
+      pure $! Missing ()
+
+-- | Create the build directory for the given input hash.
+createBuildDir :: ContentStore -> ContentHash -> IO (Path Abs Dir)
+createBuildDir store hash = do
+  let dir = mkPendingPath store hash
+  createDir dir
+  setDirWritable dir
+  return dir
+
+-- | Watch the build directory of the pending item under the given key.
+-- The returned 'Async' completes after the item is completed or failed.
 internalWatchPending
   :: ContentStore
   -> ContentHash
   -> IO (Async Update)
 internalWatchPending store hash = do
-  let dir = storePath store hash
+  let build = mkPendingPath store hash
   -- Add an inotify watch and give a signal on relevant events.
   let inotify = storeINotify store
       mask = [Attrib, MoveSelf, DeleteSelf, OnlyDir]
@@ -408,7 +502,7 @@ internalWatchPending store hash = do
   -- Signal the listener. If the 'MVar' is full,
   -- the listener didn't handle earlier signals, yet.
   let giveSignal = void $ tryPutMVar signal ()
-  watch <- addWatch inotify mask (fromAbsDir dir) $ \case
+  watch <- addWatch inotify mask (fromAbsDir build) $ \case
     Attributes True Nothing -> giveSignal
     MovedSelf True -> giveSignal
     DeletedSelf -> giveSignal
@@ -434,9 +528,10 @@ internalWatchPending store hash = do
   -- and query the status when it fires.
   -- If the status changed, fill in the update.
   update <- newEmptyMVar
-  let loop = takeMVar signal >> query store hash >>= \case
-        Pending () -> loop
-        Complete () -> tryPutMVar update $ Completed (Item dir)
+  let query' = withStoreLock store $ internalQuery store hash
+      loop = takeMVar signal >> query' >>= \case
+        Pending _ -> loop
+        Complete item -> tryPutMVar update $ Completed item
         Missing () -> tryPutMVar update Failed
   void $ async loop
   -- Wait for the update asynchronously.
@@ -460,9 +555,6 @@ readOnlyRootDirMode = writableDirMode `intersectFileModes` allButWritableMode
 withWritableStore :: ContentStore -> IO a -> IO a
 withWritableStore store =
   bracket_ (setRootDirWritable store) (setRootDirReadOnly store)
-
-isWritable :: Path Abs Dir -> IO Bool
-isWritable fp = fileAccess (fromAbsDir fp) False True False
 
 setDirWritable :: Path Abs Dir -> IO ()
 setDirWritable fp = setFileMode (fromAbsDir fp) writableDirMode

--- a/src/Control/FunFlow/Exec/Simple.hs
+++ b/src/Control/FunFlow/Exec/Simple.hs
@@ -69,7 +69,7 @@ runFlowEx _ cfg store runWrapped flow input = do
           `onException`
           CS.removeFailed store chash
     runFlow' _ (GetFromStore f) = AsyncA $ \item ->
-      f $ CS.itemPath item
+      f $ CS.itemPath store item
     runFlow' _ (Wrapped w) = runWrapped w
 
 runFlow :: forall c eff ex a b. (Coordinator c, Exception ex)

--- a/src/Control/FunFlow/External/Executor.hs
+++ b/src/Control/FunFlow/External/Executor.hs
@@ -59,7 +59,7 @@ execute store td = do
           , std_out = out
           }
         convParam = ConvParam
-          { convPath = pure . CS.itemPath
+          { convPath = pure . CS.itemPath store
           , convEnv = \e -> T.pack <$> MaybeT (getEnv $ T.unpack e)
           , convUid = lift getEffectiveUserID
           , convGid = lift getEffectiveGroupID


### PR DESCRIPTION
After an item is completed its hash is calculated and the contents
are moved to a path derived from that hash. If that hash already
exists in the store, then the new version is discarded.
A symbolic link will point from the input's content hash to the result.

In future a GC mechanism and back-references from items to the
corresponding input hashes should be added.