### PR TITLE
Add support for BSD and OSX

### DIFF
--- a/funflow.cabal
+++ b/funflow.cabal
@@ -48,6 +48,8 @@ Library
                    , Control.FunFlow.Exec.Simple
                    , Control.FunFlow.Exec.Redis
                    , Control.FunFlow.Exec.RedisJobs
+   Other-modules:
+                     Control.FunFlow.ContentStore.Notify
    Build-depends:
                  base                    >= 4.6 && <5
                , aeson                   >= 1.2.3.0
@@ -55,7 +57,6 @@ Library
                , clock
                , constraints
                , data-default
-               , hinotify
                , scientific
                , store
                , text
@@ -92,6 +93,15 @@ Library
                , unix
                , vector
                , yaml
+   if os(linux)
+     CPP-options: -DOS_Linux
+     Other-modules: Control.FunFlow.ContentStore.Notify.Linux
+     Build-depends: hinotify
+   else
+     if os(darwin) || os(freebsd)
+       CPP-options: -DOS_BSD
+       Other-modules: Control.FunFlow.ContentStore.Notify.BSD
+       Build-depends: kqueue
 
 Executable ffexecutord
   default-language:  Haskell2010

--- a/funflow.cabal
+++ b/funflow.cabal
@@ -120,6 +120,7 @@ Test-suite test-funflow
   default-language:  Haskell2010
 
   main-is: TestFunflow.hs
+  ghc-options:        -Wall -threaded
   build-depends:       base >=4.6 && <5
                      , funflow
                      , filepath
@@ -138,7 +139,7 @@ Test-suite unit-tests
   other-modules:      FunFlow.ContentStore
                       FunFlow.TestFlows
                       Control.Arrow.Async.Tests
-  ghc-options:        -Wall
+  ghc-options:        -Wall -threaded
   build-depends:      base
                     , async
                     , containers

--- a/src/Control/FunFlow/ContentHashable.hs
+++ b/src/Control/FunFlow/ContentHashable.hs
@@ -92,7 +92,14 @@ import           System.IO.Unsafe                 (unsafePerformIO)
 
 
 newtype ContentHash = ContentHash { unContentHash :: Digest SHA256 }
-  deriving (Eq, Ord, Generic, Show)
+  deriving (Eq, Ord, Generic)
+
+instance Show ContentHash where
+  showsPrec d h = showParen (d > app_prec)
+    $ showString "ContentHash \""
+    . (showString $ C8.unpack $ encodeHash h)
+    . showString "\""
+    where app_prec = 10
 
 instance Store ContentHash where
   size = contramap toBytes size

--- a/src/Control/FunFlow/ContentHashable.hs
+++ b/src/Control/FunFlow/ContentHashable.hs
@@ -45,7 +45,7 @@ import qualified Data.Aeson                    as Aeson
 import           Data.Bits                        (shiftL)
 import           Data.ByteArray                   (Bytes, MemView (MemView),
                                                    allocAndFreeze, convert)
-import           Data.ByteArray.Encoding          (Base (Base64URLUnpadded),
+import           Data.ByteArray.Encoding          (Base (Base16),
                                                    convertFromBase,
                                                    convertToBase)
 import qualified Data.ByteString                  as BS
@@ -124,15 +124,18 @@ toBytes = convert . unContentHash
 fromBytes :: BS.ByteString -> Maybe ContentHash
 fromBytes bs = ContentHash <$> digestFromByteString bs
 
+hashEncoding :: Base
+hashEncoding = Base16
+
 -- | File path appropriate encoding of a hash
 encodeHash :: ContentHash -> BS.ByteString
-encodeHash = convertToBase Base64URLUnpadded . toBytes
+encodeHash = convertToBase hashEncoding . toBytes
 
 -- | Inverse of 'encodeHash' if given a valid input.
 --
 -- prop> decodeHash (encodeHash x) = Just x
 decodeHash :: BS.ByteString -> Maybe ContentHash
-decodeHash bs = case convertFromBase Base64URLUnpadded bs of
+decodeHash bs = case convertFromBase hashEncoding bs of
   Left _  -> Nothing
   Right x -> fromBytes x
 

--- a/src/Control/FunFlow/ContentStore.hs
+++ b/src/Control/FunFlow/ContentStore.hs
@@ -99,49 +99,50 @@ module Control.FunFlow.ContentStore
   ) where
 
 
-import           Prelude                          hiding (lookup)
+import           Prelude                             hiding (lookup)
 
-import           Control.Concurrent               (threadDelay)
+import           Control.Concurrent                  (threadDelay)
 import           Control.Concurrent.Async
 import           Control.Concurrent.MVar
-import           Control.Exception                (Exception, bracket_, catch,
-                                                   throwIO)
-import           Control.FunFlow.Orphans          ()
+import           Control.Exception                   (Exception, bracket_,
+                                                      catch, throwIO)
+import           Control.FunFlow.ContentStore.Notify
+import           Control.FunFlow.Orphans             ()
 import           Control.Lens
-import           Control.Monad                    (forever, void, (<=<), (>=>))
-import           Control.Monad.Catch              (MonadMask, bracket)
-import           Control.Monad.IO.Class           (MonadIO, liftIO)
-import           Crypto.Hash                      (hashUpdate)
-import           Data.Bits                        (complement)
-import qualified Data.ByteString.Char8            as C8
-import           Data.Foldable                    (asum)
-import           Data.List                        (foldl', stripPrefix)
-import           Data.Maybe                       (fromMaybe, listToMaybe)
-import           Data.Monoid                      ((<>))
+import           Control.Monad                       (forever, void, (<=<),
+                                                      (>=>))
+import           Control.Monad.Catch                 (MonadMask, bracket)
+import           Control.Monad.IO.Class              (MonadIO, liftIO)
+import           Crypto.Hash                         (hashUpdate)
+import           Data.Bits                           (complement)
+import qualified Data.ByteString.Char8               as C8
+import           Data.Foldable                       (asum)
+import           Data.List                           (foldl', stripPrefix)
+import           Data.Maybe                          (fromMaybe, listToMaybe)
+import           Data.Monoid                         ((<>))
 import qualified Data.Store
-import           Data.String                      (IsString)
-import qualified Data.Text                        as T
-import           Data.Typeable                    (Typeable)
-import qualified Database.SQLite.Simple           as SQL
-import qualified Database.SQLite.Simple.FromField as SQL
-import qualified Database.SQLite.Simple.ToField   as SQL
-import           GHC.Generics                     (Generic)
-import           GHC.IO.Device                    (SeekMode (AbsoluteSeek))
+import           Data.String                         (IsString)
+import qualified Data.Text                           as T
+import           Data.Typeable                       (Typeable)
+import qualified Database.SQLite.Simple              as SQL
+import qualified Database.SQLite.Simple.FromField    as SQL
+import qualified Database.SQLite.Simple.ToField      as SQL
+import           GHC.Generics                        (Generic)
+import           GHC.IO.Device                       (SeekMode (AbsoluteSeek))
 import           Path
 import           Path.IO
-import           System.Directory                 (removePathForcibly)
-import           System.FilePath                  (dropTrailingPathSeparator)
-import           System.INotify
+import           System.Directory                    (removePathForcibly)
+import           System.FilePath                     (dropTrailingPathSeparator)
 import           System.Posix.Files
 import           System.Posix.IO
 import           System.Posix.Types
 
-import           Control.FunFlow.ContentHashable  (ContentHash,
-                                                   ContentHashable (..),
-                                                   DirectoryContent (..),
-                                                   contentHashUpdate_fingerprint,
-                                                   encodeHash, pathToHash,
-                                                   toBytes)
+import           Control.FunFlow.ContentHashable     (ContentHash,
+                                                      ContentHashable (..),
+                                                      DirectoryContent (..),
+                                                      contentHashUpdate_fingerprint,
+                                                      encodeHash, pathToHash,
+                                                      toBytes)
 
 
 -- | Status of an item in the store.
@@ -179,21 +180,21 @@ instance Exception StoreError
 
 -- | A hash addressed store on the file system.
 data ContentStore = ContentStore
-  { storeRoot    :: Path Abs Dir
+  { storeRoot     :: Path Abs Dir
   -- ^ Root directory of the content store.
   -- The process must be able to create this directory if missing,
   -- change permissions, and create files and directories within.
-  , storeLock    :: MVar ()
+  , storeLock     :: MVar ()
   -- ^ One global lock on store metadata to ensure thread safety.
   -- The lock is taken when item state is changed or queried.
-  , storeLockFd  :: Fd
+  , storeLockFd   :: Fd
   -- ^ One exclusive file lock to ensure multi-processing safety.
   -- Note, that file locks are shared between threads in a process,
   -- so that the file lock needs to be complemented by an `MVar`
   -- for thread-safety.
-  , storeINotify :: INotify
+  , storeNotifier :: Notifier
   -- ^ Used to watch for updates on store items.
-  , storeDb      :: SQL.Connection
+  , storeDb       :: SQL.Connection
   -- ^ Connection to the metadata SQLite database.
   }
 
@@ -272,7 +273,7 @@ open storeRoot = do
     \  )"
   setFileMode (fromAbsDir storeRoot) readOnlyRootDirMode
   storeLock <- newMVar ()
-  storeINotify <- initINotify
+  storeNotifier <- initNotifier
   return ContentStore {..}
 
 -- | Free the resources associated with the given store object.
@@ -282,7 +283,7 @@ close :: ContentStore -> IO ()
 close store = do
   takeMVar (storeLock store)
   closeFd (storeLockFd store)
-  killINotify (storeINotify store)
+  killNotifier (storeNotifier store)
   SQL.close (storeDb store)
 
 -- | Open the store under the given root and perform the given action.
@@ -626,17 +627,12 @@ internalWatchPending
 internalWatchPending store hash = do
   let build = mkPendingPath store hash
   -- Add an inotify watch and give a signal on relevant events.
-  let inotify = storeINotify store
-      mask = [Attrib, MoveSelf, DeleteSelf, OnlyDir]
+  let notifier = storeNotifier store
   signal <- newEmptyMVar
   -- Signal the listener. If the 'MVar' is full,
   -- the listener didn't handle earlier signals, yet.
   let giveSignal = void $ tryPutMVar signal ()
-  watch <- addWatch inotify mask (fromAbsDir build) $ \case
-    Attributes True Nothing -> giveSignal
-    MovedSelf True -> giveSignal
-    DeletedSelf -> giveSignal
-    _ -> return ()
+  watch <- addDirWatch notifier (fromAbsDir build) giveSignal
   -- Additionally, poll on regular intervals.
   -- Inotify doesn't cover all cases, e.g. network filesystems.
   let tenMinutes = 10 * 60 * 1000000
@@ -653,7 +649,7 @@ internalWatchPending store hash = do
         -- to miss out on the event.
         -- Note, that this may change when adding different event handlers,
         -- that remove the watch under different conditions.
-        removeWatch watch `catch` \(_::IOError) -> return ()
+        removeDirWatch watch `catch` \(_::IOError) -> return ()
   -- Listen to the signal asynchronously,
   -- and query the status when it fires.
   -- If the status changed, fill in the update.

--- a/src/Control/FunFlow/ContentStore/Notify.hs
+++ b/src/Control/FunFlow/ContentStore/Notify.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE CPP #-}
+
+module Control.FunFlow.ContentStore.Notify
+  ( Notifier
+  , initNotifier
+  , killNotifier
+
+  , Watch
+  , addDirWatch
+  , removeDirWatch
+  ) where
+
+#ifdef OS_Linux
+import           Control.FunFlow.ContentStore.Notify.Linux
+#else
+#  ifdef OS_BSD
+import           Control.FunFlow.ContentStore.Notify.BSD
+#  endif
+#endif

--- a/src/Control/FunFlow/ContentStore/Notify/BSD.hs
+++ b/src/Control/FunFlow/ContentStore/Notify/BSD.hs
@@ -1,3 +1,77 @@
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Control.FunFlow.ContentStore.Notify.BSD
-  (
+  ( Notifier
+  , initNotifier
+  , killNotifier
+
+  , Watch
+  , addDirWatch
+  , removeDirWatch
   ) where
+
+import           Control.Concurrent
+import           Control.Concurrent.Async
+import           Control.Exception
+import           Control.Monad
+import           Data.Typeable
+import           Foreign.Ptr
+import           System.KQueue
+import           System.Posix.IO
+import           System.Posix.Types
+
+type Notifier = KQueue
+
+data NotifierException
+  = RequiresThreadedRuntime
+  deriving (Show, Typeable)
+instance Exception NotifierException where
+  displayException = \case
+    -- XXX: Compile time check?
+    RequiresThreadedRuntime ->
+      "Threaded runtime required! Please rebuild with -threaded flag."
+
+initNotifier :: IO Notifier
+initNotifier = do
+  unless rtsSupportsBoundThreads $ throwIO RequiresThreadedRuntime
+  kqueue
+
+killNotifier :: Notifier -> IO ()
+killNotifier _ = return ()
+
+data Watch = Watch KQueue Fd (Async ())
+
+addDirWatch :: Notifier -> FilePath -> IO () -> IO Watch
+addDirWatch kq dir f = do
+  fd <- openFd dir ReadOnly Nothing defaultFileFlags
+  a <- async $ do
+    let event = KEvent
+          { ident = fromIntegral fd
+          , evfilter = EvfiltVnode
+          , flags = [EvAdd]
+          , fflags = [NoteDelete, NoteAttrib, NoteRename, NoteRevoke]
+          , data_ = 0
+          , udata = nullPtr
+          }
+        loop = do
+          chgs <- kevent kq [event] 1 Nothing
+          unless (null chgs) f
+          loop
+    loop `finally` closeFd fd
+  return $! Watch kq fd a
+
+removeDirWatch :: Watch -> IO ()
+removeDirWatch (Watch kq fd a) = do
+  closeFd fd
+  let event = KEvent
+        { ident = fromIntegral fd
+        , evfilter = EvfiltVnode
+        , flags = [EvDelete]
+        , fflags = []
+        , data_ = 0
+        , udata = nullPtr
+        }
+  void (kevent kq [event] 0 Nothing)
+    `catch` \(_ :: KQueueException) -> return ()
+  cancel a

--- a/src/Control/FunFlow/ContentStore/Notify/BSD.hs
+++ b/src/Control/FunFlow/ContentStore/Notify/BSD.hs
@@ -1,0 +1,3 @@
+module Control.FunFlow.ContentStore.Notify.BSD
+  (
+  ) where

--- a/src/Control/FunFlow/ContentStore/Notify/Linux.hs
+++ b/src/Control/FunFlow/ContentStore/Notify/Linux.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Control.FunFlow.ContentStore.Notify.Linux
   ( Notifier
@@ -10,6 +11,7 @@ module Control.FunFlow.ContentStore.Notify.Linux
   , removeDirWatch
   ) where
 
+import           Control.Exception (catch)
 import           System.INotify
 
 type Notifier = INotify
@@ -32,4 +34,16 @@ addDirWatch inotify dir f = addWatch inotify mask dir $ \case
     mask = [Attrib, MoveSelf, DeleteSelf, OnlyDir]
 
 removeDirWatch :: Watch -> IO ()
-removeDirWatch = removeWatch
+removeDirWatch w =
+  -- When calling `addWatch` on a path that is already being watched,
+  -- inotify will not create a new watch, but amend the existing watch
+  -- and return the same watch descriptor.
+  -- Therefore, the watch might already have been removed at this point,
+  -- which will cause an 'IOError'.
+  -- Fortunately, all event handlers to a file are called at once.
+  -- So, that removing the watch here will not cause another handler
+  -- to miss out on the event.
+  -- Note, that this may change when adding different event handlers,
+  -- that remove the watch under different conditions.
+  removeWatch w
+    `catch` \(_::IOError) -> return ()

--- a/src/Control/FunFlow/ContentStore/Notify/Linux.hs
+++ b/src/Control/FunFlow/ContentStore/Notify/Linux.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Control.FunFlow.ContentStore.Notify.Linux
+  ( Notifier
+  , initNotifier
+  , killNotifier
+
+  , Watch
+  , addDirWatch
+  , removeDirWatch
+  ) where
+
+import           System.INotify
+
+type Notifier = INotify
+
+initNotifier :: IO Notifier
+initNotifier = initINotify
+
+killNotifier :: Notifier -> IO ()
+killNotifier = killINotify
+
+type Watch = WatchDescriptor
+
+addDirWatch :: Notifier -> FilePath -> IO () -> IO Watch
+addDirWatch inotify dir f = addWatch inotify mask dir $ \case
+  Attributes True Nothing -> f
+  MovedSelf True -> f
+  DeletedSelf -> f
+  _ -> return ()
+  where
+    mask = [Attrib, MoveSelf, DeleteSelf, OnlyDir]
+
+removeDirWatch :: Watch -> IO ()
+removeDirWatch = removeWatch


### PR DESCRIPTION
Uses inotify on Linux and kqueue on BSD/OSX to watch directories in the store.
The use of kqueue seems to require a threaded runtime, otherwise `kevent` blocks indefinitely.

Switches to base16 encoding for hashes in file names.
The previous base64 URL safe encoding was case sensitive. However, HFS+ is often case insensitive.

Tested on NixOS 17.09 and FreeBSD 10.3.
FreeBSD requires a patched version of the kqueue Haskell bindings.
Patch can be found on [FreeBSD ports](https://svnweb.freebsd.org/ports/head/devel/hs-kqueue/files/patch-src__System__KQueue.chs?revision=447927&view=co&pathrev=447927).