### PR TITLE
fix `markComplete` of pre-existing item

### DIFF
--- a/funflow/src/Control/FunFlow/ContentStore.hs
+++ b/funflow/src/Control/FunFlow/ContentStore.hs
@@ -431,7 +431,7 @@ markComplete store inHash = withStoreLock store $
       let out = mkItemPath store outHash
           link' = mkCompletePath store inHash
       doesDirExist out >>= \case
-        True -> removeDir build
+        True -> removePathForcibly (fromAbsDir build)
         False -> renameDir build out
       rel <- makeRelative (parent link') out
       let from' = dropTrailingPathSeparator $ fromAbsDir link'

--- a/funflow/src/Control/FunFlow/ContentStore.hs
+++ b/funflow/src/Control/FunFlow/ContentStore.hs
@@ -83,6 +83,7 @@ module Control.FunFlow.ContentStore
   , removeAlias
 
   -- * Accessors
+  , itemHash
   , itemPath
   , root
 


### PR DESCRIPTION
Previously `removeDir` would fail since it can only remove empty directories.