### PR TITLE
Implement merging of store directories.

### DIFF
--- a/funflow/funflow.cabal
+++ b/funflow/funflow.cabal
@@ -75,7 +75,7 @@ Library
                , lens
                , memory
                , mtl
-               , path
+               , path                    > 0.6.0
                , path-io
                , process
                , random

--- a/funflow/src/Control/FunFlow/Base.hs
+++ b/funflow/src/Control/FunFlow/Base.hs
@@ -74,6 +74,10 @@ data Flow' eff a b where
   PutInStore :: ContentHashable IO a => (Path Abs Dir -> a -> IO ()) -> Flow' eff a CS.Item
   -- XXX: Constrain allowed user actions.
   GetFromStore :: (Path Abs t -> IO a) -> Flow' eff (CS.Content t) a
+  -- Internally manipulate the store. This should not be used by
+  -- client libraries.
+  InternalManipulateStore :: (CS.ContentStore -> a -> IO b)
+                          -> Flow' eff a b
   LookupAliasInStore :: Flow' eff CS.Alias (Maybe CS.Item)
   AssignAliasInStore :: Flow' eff (CS.Alias, CS.Item) ()
   Wrapped :: Properties a b -> eff a b -> Flow' eff a b
@@ -125,7 +129,6 @@ lookupAliasInStore :: Flow eff ex CS.Alias (Maybe CS.Item)
 lookupAliasInStore = effect LookupAliasInStore
 assignAliasInStore :: Flow eff ex (CS.Alias, CS.Item) ()
 assignAliasInStore = effect AssignAliasInStore
-
 
 -- | Convert a flow to a diagram, for inspection/pretty printing
 toDiagram :: Flow eff ex a b -> Diagram ex a b

--- a/funflow/src/Control/FunFlow/ContentStore.hs
+++ b/funflow/src/Control/FunFlow/ContentStore.hs
@@ -84,6 +84,9 @@ module Control.FunFlow.ContentStore
 
   -- * Accessors
   , itemPath
+  , contentPath
+  , contentItem
+  , contentFilename
   , root
 
   -- * Types
@@ -252,6 +255,19 @@ root = storeRoot
 -- | The store path of a completed item.
 itemPath :: ContentStore -> Item -> Path Abs Dir
 itemPath store = mkItemPath store . itemHash
+
+-- | Store item containing the given content.
+contentItem :: Content t -> Item
+contentItem (All i) = i
+contentItem (i :</> _) = i
+
+contentFilename :: Content File -> Path Rel File
+contentFilename (_ :</> relPath) = filename relPath
+
+-- | The absolute path to content within the store.
+contentPath :: ContentStore -> Content t -> Path Abs t
+contentPath store (All item) = itemPath store item
+contentPath store (item :</> dir) = itemPath store item </> dir
 
 -- | @open root@ opens a store under the given root directory.
 --

--- a/funflow/src/Control/FunFlow/Exec/Simple.hs
+++ b/funflow/src/Control/FunFlow/Exec/Simple.hs
@@ -120,6 +120,7 @@ runFlowEx _ cfg store runWrapped confIdent flow input = do
     runFlow' _ (GetFromStore f) = AsyncA $ \case
       CS.All item -> f $ CS.itemPath store item
       item CS.:</> path -> f $ CS.itemPath store item </> path
+    runFlow' _ (InternalManipulateStore f) = AsyncA $ \i -> f store i
     runFlow' _ LookupAliasInStore = AsyncA $ \alias ->
       CS.lookupAlias store alias
     runFlow' _ AssignAliasInStore = AsyncA $ \(alias, item) ->

--- a/funflow/src/Control/FunFlow/Steps.hs
+++ b/funflow/src/Control/FunFlow/Steps.hs
@@ -1,29 +1,58 @@
-{-# LANGUAGE Arrows              #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE GADTs               #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE QuasiQuotes         #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE Arrows                #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE QuasiQuotes           #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TupleSections         #-}
 
-module Control.FunFlow.Steps where
+module Control.FunFlow.Steps
+  ( -- * Error handling
+    retry
+    -- * Store manipulation
+  , putInStoreAt
+  , copyFileToStore
+  , copyDirToStore
+  , listDirContents
+  , mergeDirs
+  , mergeFiles
+  , readString
+  , readString_
+  , writeString
+  , writeString_
+  , readYaml
+  , writeYaml
+  , writeYaml_
+    -- * Testing and debugging
+  , promptFor
+  , printS
+  , failStep
+  , worstBernoulli
+  , pauseWith
+  , melancholicLazarus
+  )
+where
 
 import           Control.Arrow
-import           Control.Arrow.Free              (catch)
+import           Control.Arrow.Free              (catch, effect)
 import           Control.Exception               (Exception)
 import           Control.FunFlow.Base
-import           Control.FunFlow.ContentHashable ( ContentHashable
-                                                 , DirectoryContent (..)
-                                                 , FileContent (..) )
+import           Control.FunFlow.ContentHashable (ContentHashable,
+                                                  DirectoryContent (..),
+                                                  FileContent (..))
 import           Control.FunFlow.ContentStore    (Content ((:</>)))
 import qualified Control.FunFlow.ContentStore    as CS
 import           Control.Monad.Catch             (throwM)
+import           Data.Foldable                   (for_)
 import           Data.Store
+import           Data.Traversable                (for)
 import           Data.Typeable                   (Typeable)
 import qualified Data.Yaml                       as Yaml
 import           GHC.Conc                        (threadDelay)
 import           Path
 import           Path.IO
+import           System.Posix.Files              (createLink)
 import           System.Random
 
 promptFor :: Read a => Flow eff ex String a
@@ -65,6 +94,9 @@ melancholicLazarus = stepIO $ \s -> do
     else do writeFile (fromAbsFile fnm) s
             fail "lazarus fail"
 
+internalManipulateStore :: (CS.ContentStore -> a -> IO b) -> Flow eff ex a b
+internalManipulateStore = effect . InternalManipulateStore
+
 -- | `retry n s f` reruns `f` on failure at most n times with a delay of `s`
 --   seconds between retries
 retry :: forall eff ex a b. (Exception ex, Store a)
@@ -95,7 +127,7 @@ copyFileToStore = putInStoreAt $ \p (FileContent inFP) -> copyFile inFP p
 -- | @copyDirToStore (dIn, Just dOut)@ copies the contents of @dIn@ into the store
 -- under relative path @dOut@ within the subtree
 copyDirToStore :: Flow eff ex (DirectoryContent, Maybe (Path Rel Dir)) (CS.Content Dir)
-copyDirToStore = proc (inDir, mbOutDir) -> do
+copyDirToStore = proc (inDir, mbOutDir) ->
   case mbOutDir of
     Nothing -> do
       item <- putInStore (\d (DirectoryContent inDir) ->
@@ -106,6 +138,46 @@ copyDirToStore = proc (inDir, mbOutDir) -> do
       putInStoreAt (\p (DirectoryContent inDir) ->
           copyDirRecur inDir p
         ) -< (inDir, outDir)
+
+-- | List the contents of a directory within the store
+listDirContents :: Flow eff ex (CS.Content Dir)
+                               ([CS.Content Dir], [CS.Content File])
+listDirContents = internalManipulateStore
+  ( \store dir -> let
+        item = CS.contentItem dir
+        itemRoot = CS.itemPath store item
+      in do
+        (dirs, files) <- listDir $ CS.contentPath store dir
+        relDirs <- for dirs (stripProperPrefix itemRoot)
+        relFiles <- for files (stripProperPrefix itemRoot)
+        return ( (item :</>) <$> relDirs
+               , (item :</>) <$> relFiles
+               )
+  )
+
+-- | Merge a number of store directories together into a single output directory.
+--   This uses hardlinks to avoid duplicating the data on disk.
+mergeDirs :: Flow eff ex [CS.Content Dir] (CS.Content Dir)
+mergeDirs = proc inDirs -> do
+  paths <- internalManipulateStore
+    ( \store items -> return $ CS.contentPath store <$> items) -< inDirs
+  arr CS.All <<< putInStore
+    ( \d inDirs -> for_ inDirs $ \inDir -> do
+      (subDirs, files) <- listDirRecur inDir
+      for_ subDirs $ \absSubDir -> do
+        relSubDir <- stripProperPrefix inDir absSubDir
+        createDirIfMissing True (d </> relSubDir)
+      for_ files $ \absFile -> do
+        relFile <- stripProperPrefix inDir absFile
+        createLink (toFilePath absFile) (toFilePath $ d </> relFile)
+    ) -< paths
+
+-- | Merge a number of files into a single output directory.
+mergeFiles :: Flow eff ex [CS.Content File] (CS.Content Dir)
+mergeFiles = mergeDirs <<< arr (fmap containingDir)
+  where
+    containingDir :: CS.Content File -> CS.Content Dir
+    containingDir (item :</> dir) = item :</> parent dir
 
 -- | Read the contents of the given file in the store.
 readString :: Flow eff ex (CS.Content File) String

--- a/stack.yaml
+++ b/stack.yaml
@@ -43,6 +43,8 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps:
   - aeson-1.2.3.0
+  - path-0.6.1
+  - path-io-1.3.3
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
We also add a number of additional functions for manipulating content
in the store, as well as an `InternalManipulateStore` effect, which is
needed in some cases to get access to the raw 'ContentStore' object.