### PR TITLE
SQLite coordinator

### DIFF
--- a/funflow/funflow.cabal
+++ b/funflow/funflow.cabal
@@ -140,6 +140,7 @@ Test-suite unit-tests
   hs-source-dirs:     test
   main-is:            Test.hs
   other-modules:      FunFlow.ContentStore
+                      FunFlow.SQLiteCoordinator
                       FunFlow.TestFlows
                       Control.Arrow.Async.Tests
   ghc-options:        -Wall -threaded
@@ -152,6 +153,7 @@ Test-suite unit-tests
                     , funflow
                     , path
                     , path-io
+                    , process
                     , random
                     , safe-exceptions
                     , tasty

--- a/funflow/funflow.cabal
+++ b/funflow/funflow.cabal
@@ -116,7 +116,7 @@ Executable ffexecutord
                      , path
                      , text
                      , exceptions
-                     , optparse-generic
+                     , optparse-applicative
 
 Test-suite test-funflow
   type:       exitcode-stdio-1.0

--- a/funflow/funflow.cabal
+++ b/funflow/funflow.cabal
@@ -42,6 +42,7 @@ Library
                    , Control.FunFlow.External.Coordinator
                    , Control.FunFlow.External.Coordinator.Memory
                    , Control.FunFlow.External.Coordinator.Redis
+                   , Control.FunFlow.External.Coordinator.SQLite
                    , Control.FunFlow.Lock
                    , Control.FunFlow.Orphans
                    , Control.FunFlow.Steps
@@ -84,6 +85,7 @@ Library
                , sqlite-simple
                , template-haskell >= 2.11
                , text
+               , time
                , transformers
                , pretty
                , bytestring

--- a/funflow/funflow.cabal
+++ b/funflow/funflow.cabal
@@ -42,6 +42,7 @@ Library
                    , Control.FunFlow.External.Coordinator
                    , Control.FunFlow.External.Coordinator.Memory
                    , Control.FunFlow.External.Coordinator.Redis
+                   , Control.FunFlow.Lock
                    , Control.FunFlow.Orphans
                    , Control.FunFlow.Steps
                    , Control.FunFlow.Pretty

--- a/funflow/src/Control/FunFlow/ContentStore.hs
+++ b/funflow/src/Control/FunFlow/ContentStore.hs
@@ -134,13 +134,11 @@ import qualified Database.SQLite.Simple              as SQL
 import qualified Database.SQLite.Simple.FromField    as SQL
 import qualified Database.SQLite.Simple.ToField      as SQL
 import           GHC.Generics                        (Generic)
-import           GHC.IO.Device                       (SeekMode (AbsoluteSeek))
 import           Path
 import           Path.IO
 import           System.Directory                    (removePathForcibly)
 import           System.FilePath                     (dropTrailingPathSeparator)
 import           System.Posix.Files
-import           System.Posix.IO
 import           System.Posix.Types
 
 import           Control.FunFlow.ContentHashable     (ContentHash,
@@ -149,6 +147,7 @@ import           Control.FunFlow.ContentHashable     (ContentHash,
                                                       contentHashUpdate_fingerprint,
                                                       encodeHash, pathToHash,
                                                       toBytes)
+import           Control.FunFlow.Lock
 
 
 -- | Status of an item in the store.
@@ -190,14 +189,9 @@ data ContentStore = ContentStore
   -- ^ Root directory of the content store.
   -- The process must be able to create this directory if missing,
   -- change permissions, and create files and directories within.
-  , storeLock     :: MVar ()
-  -- ^ One global lock on store metadata to ensure thread safety.
+  , storeLock     :: Lock
+  -- ^ Write lock on store metadata to ensure multi thread and process safety.
   -- The lock is taken when item state is changed or queried.
-  , storeLockFd   :: Fd
-  -- ^ One exclusive file lock to ensure multi-processing safety.
-  -- Note, that file locks are shared between threads in a process,
-  -- so that the file lock needs to be complemented by an `MVar`
-  -- for thread-safety.
   , storeNotifier :: Notifier
   -- ^ Used to watch for updates on store items.
   , storeDb       :: SQL.Connection
@@ -281,27 +275,26 @@ contentPath store (item :</> dir) = itemPath store item </> dir
 open :: Path Abs Dir -> IO ContentStore
 open storeRoot = do
   createDirIfMissing True storeRoot
-  storeLockFd <- createFile (fromAbsFile $ lockPath storeRoot) ownerWriteMode
-  storeDb <- SQL.open (fromAbsFile $ dbPath storeRoot)
-  SQL.execute_ storeDb
-    "CREATE TABLE IF NOT EXISTS\
-    \  aliases\
-    \  ( hash TEXT PRIMARY KEY\
-    \  , dest TEXT NOT NULL\
-    \  , name TEXT NOT NULL\
-    \  )"
-  setFileMode (fromAbsDir storeRoot) readOnlyRootDirMode
-  storeLock <- newMVar ()
-  storeNotifier <- initNotifier
-  return ContentStore {..}
+  storeLock <- openLock (lockPath storeRoot)
+  withLock storeLock $ do
+    storeDb <- SQL.open (fromAbsFile $ dbPath storeRoot)
+    SQL.execute_ storeDb
+      "CREATE TABLE IF NOT EXISTS\
+      \  aliases\
+      \  ( hash TEXT PRIMARY KEY\
+      \  , dest TEXT NOT NULL\
+      \  , name TEXT NOT NULL\
+      \  )"
+    setFileMode (fromAbsDir storeRoot) readOnlyRootDirMode
+    storeNotifier <- initNotifier
+    return ContentStore {..}
 
 -- | Free the resources associated with the given store object.
 --
 -- The store object may not be used afterwards.
 close :: ContentStore -> IO ()
 close store = do
-  takeMVar (storeLock store)
-  closeFd (storeLockFd store)
+  closeLock (storeLock store)
   killNotifier (storeNotifier store)
   SQL.close (storeDb store)
 
@@ -559,32 +552,10 @@ lockPath = (</> [relfile|lock|])
 dbPath :: Path Abs Dir -> Path Abs File
 dbPath = (</> [relfile|metadata.db|])
 
-makeLockDesc :: LockRequest -> FileLock
-makeLockDesc req = (req, AbsoluteSeek, COff 0, COff 1)
-
-acquireStoreFileLock :: ContentStore -> IO ()
-acquireStoreFileLock ContentStore {storeLockFd} = do
-  let lockDesc = makeLockDesc WriteLock
-  waitToSetLock storeLockFd lockDesc
-
-releaseStoreFileLock :: ContentStore -> IO ()
-releaseStoreFileLock ContentStore {storeLockFd} = do
-  let lockDesc = makeLockDesc Unlock
-  setLock storeLockFd lockDesc
-
--- | Holds an exclusive write lock on the global lock file
--- for the duration of the given action.
-withStoreFileLock :: ContentStore -> IO a -> IO a
-withStoreFileLock store =
-  bracket_ (acquireStoreFileLock store) (releaseStoreFileLock store)
-
 -- | Holds a lock on the global 'MVar' and on the global lock file
 -- for the duration of the given action.
 withStoreLock :: ContentStore -> IO a -> IO a
-withStoreLock store action =
-  withMVar (storeLock store) $ \() ->
-    withStoreFileLock store $
-      action
+withStoreLock store = withLock (storeLock store)
 
 prefixHashPath :: C8.ByteString -> ContentHash -> Path Rel Dir
 prefixHashPath pref hash

--- a/funflow/src/Control/FunFlow/ContentStore.hs
+++ b/funflow/src/Control/FunFlow/ContentStore.hs
@@ -120,6 +120,7 @@ import           Control.Monad                       (forever, void, (<=<),
 import           Control.Monad.Catch                 (MonadMask, bracket)
 import           Control.Monad.IO.Class              (MonadIO, liftIO)
 import           Crypto.Hash                         (hashUpdate)
+import           Data.Aeson                          (FromJSON, ToJSON)
 import           Data.Bits                           (complement)
 import qualified Data.ByteString.Char8               as C8
 import           Data.Foldable                       (asum)
@@ -208,6 +209,8 @@ instance Monad m => ContentHashable m Item where
     >=> pure . flip hashUpdate (toBytes $ itemHash item)
     $ ctx
 
+instance FromJSON Item
+instance ToJSON Item
 instance Data.Store.Store Item
 
 -- | File or directory within a content store 'Item'.
@@ -255,7 +258,7 @@ itemPath store = mkItemPath store . itemHash
 
 -- | Store item containing the given content.
 contentItem :: Content t -> Item
-contentItem (All i) = i
+contentItem (All i)    = i
 contentItem (i :</> _) = i
 
 contentFilename :: Content File -> Path Rel File
@@ -263,7 +266,7 @@ contentFilename (_ :</> relPath) = filename relPath
 
 -- | The absolute path to content within the store.
 contentPath :: ContentStore -> Content t -> Path Abs t
-contentPath store (All item) = itemPath store item
+contentPath store (All item)      = itemPath store item
 contentPath store (item :</> dir) = itemPath store item </> dir
 
 -- | @open root@ opens a store under the given root directory.

--- a/funflow/src/Control/FunFlow/External.hs
+++ b/funflow/src/Control/FunFlow/External.hs
@@ -10,6 +10,7 @@ module Control.FunFlow.External where
 import           Control.FunFlow.ContentHashable (ContentHash, ContentHashable)
 import qualified Control.FunFlow.ContentStore    as CS
 import           Control.Lens.TH
+import           Data.Aeson                      (FromJSON, ToJSON)
 import           Data.Semigroup
 import           Data.Store                      (Store)
 import           Data.String                     (IsString (..))
@@ -35,6 +36,8 @@ data ParamField
   deriving Generic
 
 instance Monad m => ContentHashable m ParamField
+instance FromJSON ParamField
+instance ToJSON ParamField
 instance Store ParamField
 
 -- | A parameter to an external task
@@ -49,6 +52,8 @@ instance IsString Param where
   fromString s = Param [ParamText (fromString s)]
 
 instance Monad m => ContentHashable m Param
+instance FromJSON Param
+instance ToJSON Param
 instance Store Param
 
 -- | Converter of path components.
@@ -125,6 +130,8 @@ data ExternalTask = ExternalTask {
 } deriving Generic
 
 instance Monad m => ContentHashable m ExternalTask
+instance FromJSON ExternalTask
+instance ToJSON ExternalTask
 instance Store ExternalTask
 
 data TaskDescription = TaskDescription {

--- a/funflow/src/Control/FunFlow/External/Coordinator.hs
+++ b/funflow/src/Control/FunFlow/External/Coordinator.hs
@@ -23,7 +23,7 @@ instance Store TimeSpec
 -- | Information about an executor capable of running tasks. Currently this
 --   is just a newtype wrapper around hostname.
 newtype Executor = Executor HostName
-  deriving Store
+  deriving (Show, Store)
 
 data TaskStatus =
     -- | Task is in the queue and has not begun executing
@@ -32,6 +32,7 @@ data TaskStatus =
   | Completed ExecutionInfo
     -- | Task has failed with failure count
   | Failed ExecutionInfo Int
+  deriving Show
 
 data TaskInfo =
     KnownTask TaskStatus
@@ -40,7 +41,7 @@ data TaskInfo =
 data ExecutionInfo = ExecutionInfo {
     _eiExecutor :: Executor
   , _eiElapsed  :: TimeSpec
-  }
+  } deriving Show
 
 class Coordinator c where
   type Config c

--- a/funflow/src/Control/FunFlow/External/Coordinator/Redis.hs
+++ b/funflow/src/Control/FunFlow/External/Coordinator/Redis.hs
@@ -10,7 +10,9 @@
 {-# LANGUAGE TupleSections              #-}
 {-# LANGUAGE TypeFamilies               #-}
 
-module Control.FunFlow.External.Coordinator.Redis where
+module Control.FunFlow.External.Coordinator.Redis
+  ( Redis (..)
+  ) where
 
 import qualified Control.FunFlow.ContentHashable      as CHash
 import           Control.FunFlow.External

--- a/funflow/src/Control/FunFlow/External/Coordinator/SQLite.hs
+++ b/funflow/src/Control/FunFlow/External/Coordinator/SQLite.hs
@@ -1,0 +1,297 @@
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TypeFamilies      #-}
+{-# LANGUAGE QuasiQuotes       #-}
+
+module Control.FunFlow.External.Coordinator.SQLite
+  ( SQLite (..)
+  ) where
+
+import           Control.Concurrent                   (threadDelay)
+import           Control.Exception
+import           Control.FunFlow.ContentHashable
+import           Control.FunFlow.External
+import           Control.FunFlow.External.Coordinator
+import           Control.FunFlow.Lock
+import           Control.Lens
+import           Control.Monad.IO.Class
+import qualified Data.Aeson                           as Json
+import qualified Data.ByteString.Char8                as C8
+import qualified Data.Text                            as T
+import           Data.Typeable                        (Typeable)
+import qualified Database.SQLite.Simple               as SQL
+import qualified Database.SQLite.Simple.FromField     as SQL
+import qualified Database.SQLite.Simple.Ok            as SQL
+import qualified Database.SQLite.Simple.ToField       as SQL
+import           Path
+import           Path.IO
+import           System.Clock
+
+-- | SQLite coordinator tag.
+data SQLite = SQLite
+
+-- | SQLite coordinator hook.
+data SQLiteHook = SQLiteHook
+  { _sqlConn :: SQL.Connection
+  , _sqlLock :: Lock
+  }
+makeLenses ''SQLiteHook
+
+-- | Take the lock and run the given action on the SQLite connection.
+withSQLite :: SQLiteHook -> (SQL.Connection -> IO a) -> IO a
+withSQLite hook action = withLock (hook^.sqlLock) $ action (hook^.sqlConn)
+
+-- | Enumeration of possible 'TaskStatus' cases for SQLite status column.
+data SqlTaskStatus
+  = SqlPending
+  | SqlRunning
+  | SqlCompleted
+  | SqlFailed
+  deriving Enum
+instance SQL.FromField SqlTaskStatus where
+  fromField field = do
+    n <- SQL.fromField field
+    pure $! toEnum n
+instance SQL.ToField SqlTaskStatus where
+  toField = SQL.toField . fromEnum
+
+-- | Wrapper around 'Executor' for SQLite serialization.
+newtype SqlExecutor = SqlExecutor { getSqlExecutor :: Executor }
+instance SQL.FromField SqlExecutor where
+  fromField field = SqlExecutor . Executor <$> SQL.fromField field
+instance SQL.ToField SqlExecutor where
+  toField (SqlExecutor (Executor host)) = SQL.toField host
+
+-- | SQLite task info query result.
+data SqlTaskInfo = SqlTaskInfo
+  { _stiStatus   :: SqlTaskStatus
+  , _stiExecutor :: Maybe SqlExecutor
+  , _stiElapsed  :: Maybe Integer
+  , _stiExitCode :: Maybe Int
+  }
+makeLenses '' SqlTaskInfo
+instance SQL.FromRow SqlTaskInfo where
+  fromRow = SqlTaskInfo
+    <$> SQL.field
+    <*> SQL.field
+    <*> SQL.field
+    <*> SQL.field
+
+-- | Wrapper around 'ExternalTask' for SQLite serialization.
+newtype SqlExternal = SqlExternal { getSqlExternal :: ExternalTask }
+instance SQL.FromField SqlExternal where
+  fromField field = do
+    bs <- SQL.fromField field
+    case Json.eitherDecode bs of
+      Left err -> SQL.Errors [toException $ DecodingError "task" err]
+      Right x  -> pure $! SqlExternal x
+instance SQL.ToField SqlExternal where
+  toField = SQL.toField . Json.encode . getSqlExternal
+
+-- | Wrapper around 'TaskDescription' for SQLite serialization.
+newtype SqlTask = SqlTask TaskDescription
+instance SQL.FromRow SqlTask where
+  fromRow = do
+    output <- SQL.field
+    SqlExternal task <- SQL.field
+    pure $! SqlTask $! TaskDescription
+      { _tdOutput = output
+      , _tdTask = task
+      }
+
+-- | Errors that can occur when interacting with the SQLite coordinator.
+data SQLiteCoordinatorError
+  = MissingDBTaskEntry ContentHash T.Text
+    -- | @MissingDBTaskEntry output field@
+    --   The task database entry is missing a field.
+  | DecodingError T.Text String
+    -- | @DecodingError field error@
+    --   Failed to decode the field.
+  | NonRunningTask ContentHash
+    -- | @NonRunningTask output@
+    --   The task is not running.
+  | IllegalStatusUpdate ContentHash TaskStatus
+    -- | @IllegalStatusUpdate output status@
+    --   Cannot update the status of the task.
+  deriving (Show, Typeable)
+instance Exception SQLiteCoordinatorError where
+  displayException (MissingDBTaskEntry output field) =
+    "Missing field in SQLite task entry '"
+    ++ T.unpack field
+    ++ "' for output "
+    ++ C8.unpack (encodeHash output)
+  displayException (DecodingError field err) =
+    "Failed to decode field '"
+    ++ T.unpack field
+    ++ "': "
+    ++ err
+  displayException (NonRunningTask output) =
+    "Task was not running when expected: "
+    ++ C8.unpack (encodeHash output)
+  displayException (IllegalStatusUpdate output status) =
+    "Illegal status update for "
+    ++ C8.unpack (encodeHash output)
+    ++ ": "
+    ++ show status
+
+-- | Helper for @NULL@ valued data-base fields.
+--
+-- Throws 'MissingDBTaskEntry' on 'Nothing', otherwise returns the value.
+fromMaybeField :: MonadIO m => ContentHash -> T.Text -> Maybe a -> m a
+fromMaybeField output f = \case
+  Nothing -> liftIO $ throwIO $ MissingDBTaskEntry output f
+  Just x -> pure x
+
+-- | Unlifted version of 'taskInfo'.
+taskInfo' :: SQLiteHook -> ContentHash -> IO TaskInfo
+taskInfo' hook output = do
+  r <- withSQLite hook $ \conn -> SQL.queryNamed conn
+    "SELECT status, executor, elapsed, exit_code FROM tasks\
+    \ WHERE\
+    \  output = :output"
+    [ ":output" SQL.:= output ]
+  case r of
+    [] -> pure UnknownTask
+    (ti:_) -> case ti^.stiStatus of
+      SqlPending -> pure $! KnownTask Pending
+      SqlRunning -> do
+        executor <- fromMaybeField output "executor" (ti^.stiExecutor)
+        pure $! KnownTask $! Running ExecutionInfo
+          { _eiExecutor = getSqlExecutor executor
+          , _eiElapsed = fromNanoSecs 0
+          }
+      SqlCompleted -> do
+        executor <- fromMaybeField output "executor" (ti^.stiExecutor)
+        elapsed <- fromMaybeField output "elapsed" (ti^.stiElapsed)
+        pure $! KnownTask $! Completed ExecutionInfo
+          { _eiExecutor = getSqlExecutor executor
+          , _eiElapsed = fromNanoSecs elapsed
+          }
+      SqlFailed -> do
+        executor <- fromMaybeField output "executor" (ti^.stiExecutor)
+        elapsed <- fromMaybeField output "elapsed" (ti^.stiElapsed)
+        exitCode <- fromMaybeField output "exit_code" (ti^.stiExitCode)
+        pure $! KnownTask $! Failed
+          ExecutionInfo
+            { _eiExecutor = getSqlExecutor executor
+            , _eiElapsed = fromNanoSecs elapsed
+            }
+          exitCode
+
+instance Coordinator SQLite where
+  type Config SQLite = Path Abs Dir
+  type Hook SQLite = SQLiteHook
+
+  initialise dir = liftIO $ do
+    createDirIfMissing True dir
+    lock <- openLock (dir </> [relfile|lock|])
+    withLock lock $ do
+      conn <- SQL.open $ fromAbsFile (dir </> [relfile|db.sqlite|])
+      SQL.execute_ conn
+        "CREATE TABLE IF NOT EXISTS\
+        \  tasks\
+        \  ( output TEXT PRIMARY KEY\
+        \  , status INT NOT NULL\
+        \  , executor TEXT\
+        \  , elapsed INT\
+        \  , exit_code INT\
+        \  , task TEXT NOT NULL\
+        \  )"
+      return SQLiteHook
+        { _sqlConn = conn
+        , _sqlLock = lock
+        }
+
+  submitTask hook td = liftIO $
+    withSQLite hook $ \conn -> SQL.executeNamed conn
+      "INSERT OR IGNORE INTO\
+      \  tasks (output, status, task)\
+      \ VALUES\
+      \  (:output, :status, :task)"
+      [ ":output" SQL.:= (td^.tdOutput)
+      , ":status" SQL.:= SqlPending
+      , ":task" SQL.:= SqlExternal (td^.tdTask)
+      ]
+
+  queueSize hook = liftIO $ do
+    [[n]] <- withSQLite hook $ \conn -> SQL.queryNamed conn
+      "SELECT COUNT(*) FROM tasks WHERE status = :pending"
+      [ ":pending" SQL.:= SqlPending ]
+    return n
+
+  taskInfo hook output = liftIO $
+    taskInfo' hook output
+
+  popTask hook executor = liftIO $
+    withSQLite hook $ \conn -> SQL.withTransaction conn $ do
+      r <- SQL.queryNamed conn
+        "SELECT output, task FROM tasks\
+        \ WHERE\
+        \  status = :pending\
+        \ LIMIT 1"
+        [ ":pending" SQL.:= SqlPending ]
+      case r of
+        [] -> pure Nothing
+        (SqlTask td:_) -> do
+          SQL.executeNamed conn
+            "UPDATE tasks\
+            \ SET\
+            \  status = :status,\
+            \  executor = :executor\
+            \ WHERE\
+            \  output = :output"
+            [ ":status" SQL.:= SqlRunning
+            , ":executor" SQL.:= SqlExecutor executor
+            , ":output" SQL.:= td^.tdOutput
+            ]
+          pure $! Just td
+
+  awaitTask hook output = liftIO $ loop
+    where
+      -- XXX: SQLite has callback mechanisms built-in (e.g. @sqlite3_commit_hook@).
+      --   Unfortunately, @direct-sqlite@, which @sqlite-simple@ builds on top of,
+      --   doesn't expose this functionality at the moment.
+      loop = taskInfo' hook output >>= \case
+        KnownTask Pending -> sleep >> loop
+        KnownTask (Running _) -> sleep >> loop
+        ti -> pure ti
+      sleep = liftIO $ threadDelay oneSeconds
+      oneSeconds = 1000000
+
+  updateTaskStatus hook output ts = liftIO $
+    withSQLite hook $ \conn -> SQL.withTransaction conn $ do
+      r <- SQL.queryNamed conn
+        "SELECT status FROM tasks\
+        \ WHERE\
+        \  output = :output"
+        [ ":output" SQL.:= output ]
+      case r of
+        [SqlRunning]:_ -> case ts of
+          Completed ei -> SQL.executeNamed conn
+            "UPDATE tasks\
+            \ SET\
+            \  status = :completed,\
+            \  elapsed = :elapsed\
+            \ WHERE\
+            \  output = :output"
+            [ ":completed" SQL.:= SqlCompleted
+            , ":elapsed" SQL.:= toNanoSecs (ei^.eiElapsed)
+            , ":output" SQL.:= output
+            ]
+          Failed ei exitCode -> SQL.executeNamed conn
+            "UPDATE tasks\
+            \ SET\
+            \  status = :failed,\
+            \  elapsed = :elapsed,\
+            \  exit_code = :exit_code\
+            \ WHERE\
+            \  output = :output"
+            [ ":failed" SQL.:= SqlFailed
+            , ":elapsed" SQL.:= toNanoSecs (ei^.eiElapsed)
+            , ":exit_code" SQL.:= exitCode
+            , ":output" SQL.:= output
+            ]
+          Pending -> throwIO $ IllegalStatusUpdate output ts
+          Running _ -> throwIO $ IllegalStatusUpdate output ts
+        _ -> throwIO $ NonRunningTask output

--- a/funflow/src/Control/FunFlow/Lock.hs
+++ b/funflow/src/Control/FunFlow/Lock.hs
@@ -1,0 +1,76 @@
+-- | Thread and process write lock.
+--
+-- Allows synchronisation between threads and processes.
+-- Uses an 'MVar' for synchronisation between threads
+-- and fcntl write locks for synchronisation between processes.
+--
+-- Only ever have one 'Lock' object per lock file per process!
+module Control.FunFlow.Lock
+  ( Lock
+  , openLock
+  , closeLock
+  , withLock
+  ) where
+
+import           Control.Concurrent.MVar
+import           Control.Exception
+import           GHC.IO.Device           (SeekMode (AbsoluteSeek))
+import           Path
+import           System.Posix.Files
+import           System.Posix.IO
+import           System.Posix.Types
+
+-- | Thread and process write lock.
+--
+-- Only ever have one 'Lock' object per lock file per process!
+data Lock = Lock
+  { lockMVar :: MVar ()
+  , lockFd   :: Fd
+  }
+
+-- | Open the lock file and create a lock object.
+--
+-- This does not acquire the lock.
+--
+-- Only ever have one 'Lock' object per lock file per process!
+openLock :: Path Abs File -> IO Lock
+openLock lockFile = do
+  mvar <- newMVar ()
+  fd <- createFile (fromAbsFile $ lockFile) ownerWriteMode
+  return $! Lock
+    { lockMVar = mvar
+    , lockFd = fd
+    }
+
+-- | Close the lock file.
+--
+-- Does not release the lock.
+--
+-- Blocks if the lock is taken.
+closeLock :: Lock -> IO ()
+closeLock lock = do
+  takeMVar (lockMVar lock)
+  closeFd (lockFd lock)
+
+-- | Acquire the lock for the duration of the given action and release after.
+withLock :: Lock -> IO a -> IO a
+withLock lock action =
+  withMVar (lockMVar lock) $ \() ->
+    bracket_ (acquireFileLock $ lockFd lock) (releaseFileLock $ lockFd lock) $
+      action
+
+----------------------------------------------------------------------
+-- Internals
+
+makeLockDesc :: LockRequest -> FileLock
+makeLockDesc req = (req, AbsoluteSeek, COff 0, COff 1)
+
+acquireFileLock :: Fd -> IO ()
+acquireFileLock fd = do
+  let lockDesc = makeLockDesc WriteLock
+  waitToSetLock fd lockDesc
+
+releaseFileLock :: Fd -> IO ()
+releaseFileLock fd = do
+  let lockDesc = makeLockDesc Unlock
+  setLock fd lockDesc

--- a/funflow/test/FunFlow/SQLiteCoordinator.hs
+++ b/funflow/test/FunFlow/SQLiteCoordinator.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE Arrows            #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+
+module FunFlow.SQLiteCoordinator where
+
+import           Control.Arrow
+import           Control.Arrow.Free
+import           Control.Exception
+import           Control.FunFlow
+import qualified Control.FunFlow.ContentStore                as CS
+import           Control.FunFlow.Exec.Simple
+import           Control.FunFlow.External.Coordinator.SQLite
+import           Control.FunFlow.Steps
+import           Control.Monad
+import           Data.String                                 (fromString)
+import           Path
+import           Path.IO
+import           System.Process
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+storeDir :: Path Rel Dir
+storeDir = [reldir|store|]
+
+dbDir :: Path Rel Dir
+dbDir = [reldir|coord|]
+
+-- XXX: Reduce noise by piping stdout/stderr to a logfile.
+spawnExecutor :: Path Abs Dir -> IO ProcessHandle
+spawnExecutor wd = spawnProcess "ffexecutord"
+  ["sqlite", fromAbsDir $ wd </> storeDir, fromAbsDir $ wd </> dbDir]
+
+spawnExecutors :: Path Abs Dir -> Int -> IO [ProcessHandle]
+spawnExecutors wd n = replicateM n (spawnExecutor wd)
+
+killExecutors :: [ProcessHandle] -> IO ()
+killExecutors = mapM_ terminateProcess
+
+withExecutors :: Path Abs Dir -> Int -> IO a -> IO a
+withExecutors wd n = bracket (spawnExecutors wd n) killExecutors . const
+
+runTestFlow :: Path Abs Dir -> SimpleFlow a b -> a -> IO (Either SomeException b)
+runTestFlow wd flow' input =
+  CS.withStore (wd </> storeDir) $ \store ->
+    runSimpleFlow SQLite (wd </> dbDir) store flow' input
+
+echo :: SimpleFlow String CS.Item
+echo = external $ \msg -> ExternalTask
+  { _etCommand = "echo"
+  , _etWriteToStdOut = True
+  , _etParams = ["-n", fromString msg]
+  }
+
+flow :: SimpleFlow () String
+flow = proc () -> do
+  (a, (b, (c, d)))
+    <- echo *** echo *** echo *** echo
+    -< ("a", ("b", ("c", "d")))
+  (e, (f, (g, h)))
+    <- echo *** echo *** echo *** echo
+    -< ("e", ("f", ("g", "h")))
+  arr concat <<< mapA readString_ -< [a, b, c, d, e, f, g, h]
+
+tests :: TestTree
+tests = testGroup "SQLite Coordinator"
+  [ testCase "echo flow" $
+      withSystemTempDir "funflow_sqlite_" $ \wd ->
+      withExecutors wd 4 $ do
+        r <- runTestFlow wd flow ()
+        case r of
+          Left err -> assertFailure $ displayException err
+          Right x  -> x @?= "abcdefgh"
+  ]

--- a/funflow/test/Test.hs
+++ b/funflow/test/Test.hs
@@ -1,5 +1,6 @@
 import qualified Control.Arrow.Async.Tests
 import qualified FunFlow.ContentStore
+import qualified FunFlow.SQLiteCoordinator
 import qualified FunFlow.TestFlows
 import           Test.Tasty
 
@@ -11,4 +12,5 @@ tests = testGroup "Unit Tests"
   [ FunFlow.ContentStore.tests
   , Control.Arrow.Async.Tests.tests
   , FunFlow.TestFlows.tests
+  , FunFlow.SQLiteCoordinator.tests
   ]


### PR DESCRIPTION
Allows for purely file-sytem based coordination.
While SQLite does use file locks to manage concurrent access by multiple
processes. It does so insufficiently well for this use-case.
Instead of wait on a locked file it typically errors out, forcing the
user to implement retry logic. In some cases it was found to simply
dead-lock.
These problems are circumvented by using an external fcntl write lock
for synchronisation.

I've also modified `ffexecutord` to allow to use either the Redis or the SQLite coordinator.

The tests include a test-case that spawns a number of `ffexecutord` instances using the SQLite coordinator and runs a simple example flow.