### PR TITLE
Mark tasks pending before submitting to coordinator

### DIFF
--- a/funflow/src/Control/FunFlow/ContentStore.hs
+++ b/funflow/src/Control/FunFlow/ContentStore.hs
@@ -665,8 +665,7 @@ internalWatchPending store hash = do
   watch <- addDirWatch notifier (fromAbsDir build) giveSignal
   -- Additionally, poll on regular intervals.
   -- Inotify/Kqueue don't cover all cases, e.g. network filesystems.
-  let tenMinutes = 10 * 60 * 1000000
-  ticker <- async $ forever $ threadDelay tenMinutes >> giveSignal
+  ticker <- async $ forever $ threadDelay 3007000 >> giveSignal
   let stopWatching = do
         cancel ticker
         removeDirWatch watch

--- a/funflow/src/Control/FunFlow/ContentStore.hs
+++ b/funflow/src/Control/FunFlow/ContentStore.hs
@@ -67,7 +67,7 @@ module Control.FunFlow.ContentStore
   , waitUntilComplete
 
   -- * Construct Items
-  , constructOrWait
+  , constructOrAsync
   , constructIfMissing
   , markPending
   , markComplete
@@ -402,11 +402,11 @@ waitUntilComplete store hash = lookupOrWait store hash >>= \case
 
 -- | Atomically query the state under the given key and mark pending if missing.
 -- Return an 'Control.Concurrent.Async' to await updates, if already pending.
-constructOrWait
+constructOrAsync
   :: ContentStore
   -> ContentHash
   -> IO (Status (Path Abs Dir) (Async Update) Item)
-constructOrWait store hash = withStoreLock store $
+constructOrAsync store hash = withStoreLock store $
   internalQuery store hash >>= \case
     Complete item -> return $ Complete item
     Missing () -> withWritableStore store $

--- a/funflow/src/Control/FunFlow/ContentStore.hs
+++ b/funflow/src/Control/FunFlow/ContentStore.hs
@@ -405,7 +405,13 @@ waitUntilComplete store hash = lookupOrWait store hash >>= \case
     Failed -> return $ Nothing
 
 -- | Atomically query the state under the given key and mark pending if missing.
--- Return an 'Control.Concurrent.Async' to await updates, if already pending.
+--
+-- Returns @'Complete' item@ if the item is complete.
+-- Returns @'Pending' async@ if the item is pending, where @async@ is an
+-- 'Control.Concurrent.Async' to await updates on.
+-- Returns @'Missing' buildDir@ if the item was missing, and is now pending.
+-- It should be constructed in the given @buildDir@,
+-- and then marked as complete using 'markComplete'.
 constructOrAsync
   :: ContentStore
   -> ContentHash
@@ -420,6 +426,11 @@ constructOrAsync store hash = withStoreLock store $
 -- | Atomically query the state under the given key and mark pending if missing.
 -- Wait for the item to be completed, if already pending.
 -- Throws a 'FailedToConstruct' error if construction fails.
+--
+-- Returns @'Complete' item@ if the item is complete.
+-- Returns @'Missing' buildDir@ if the item was missing, and is now pending.
+-- It should be constructed in the given @buildDir@,
+-- and then marked as complete using 'markComplete'.
 constructOrWait
   :: ContentStore
   -> ContentHash

--- a/funflow/src/Control/FunFlow/ContentStore.hs
+++ b/funflow/src/Control/FunFlow/ContentStore.hs
@@ -84,6 +84,7 @@ module Control.FunFlow.ContentStore
   , listAliases
 
   -- * Accessors
+  , buildPath
   , itemHash
   , itemPath
   , contentPath
@@ -251,6 +252,12 @@ newtype Alias = Alias { unAlias :: T.Text }
 -- | The root directory of the store.
 root :: ContentStore -> Path Abs Dir
 root = storeRoot
+
+-- | Path of the build directory of a pending item.
+--
+-- Beware, this does not check whether the item is actually pending.
+buildPath :: ContentStore -> ContentHash -> Path Abs Dir
+buildPath = mkPendingPath
 
 -- | The store path of a completed item.
 itemPath :: ContentStore -> Item -> Path Abs Dir

--- a/funflow/src/Control/FunFlow/Exec/Simple.hs
+++ b/funflow/src/Control/FunFlow/Exec/Simple.hs
@@ -55,7 +55,7 @@ runFlowEx _ cfg store runWrapped confIdent flow input = do
     withStoreCache c f = let
         chashOf i = cacherKey c confIdent i
         checkStore = AsyncA $ \chash -> do
-          instruction <- CS.constructOrWait store chash
+          instruction <- CS.constructOrAsync store chash
           case instruction of
             CS.Pending a -> do
               update <- wait a
@@ -94,7 +94,7 @@ runFlowEx _ cfg store runWrapped confIdent flow input = do
       $ AsyncA f
     runFlow' po (External toTask) = AsyncA $ \x -> do
       chash <- contentHash (x, toTask x)
-      CS.constructOrWait store chash >>= \case
+      CS.constructOrAsync store chash >>= \case
         CS.Complete item -> return item
         CS.Pending a -> wait a >>= \case
           CS.Completed item -> return item
@@ -106,7 +106,7 @@ runFlowEx _ cfg store runWrapped confIdent flow input = do
             Just item -> return item
     runFlow' _ (PutInStore f) = AsyncA $ \x -> do
       chash <- contentHash x
-      instruction <- CS.constructOrWait store chash
+      instruction <- CS.constructOrAsync store chash
       case instruction of
         CS.Pending a -> do
           update <- wait a

--- a/funflow/src/Control/FunFlow/External/Coordinator.hs
+++ b/funflow/src/Control/FunFlow/External/Coordinator.hs
@@ -51,8 +51,7 @@ class Coordinator c where
   initialise :: MonadIO m => Config c -> m (Hook c)
 
   -- | Submit a task to the task queue.
-  --   If this task is not currently running, then
-  --   it should not be re-added to the task queue as a result of this call.
+  --   It is allowed to overwrite a known task.
   submitTask :: MonadIO m => Hook c -> TaskDescription -> m ()
 
   -- | View the size of the current task queue

--- a/funflow/src/Control/FunFlow/External/Coordinator.hs
+++ b/funflow/src/Control/FunFlow/External/Coordinator.hs
@@ -51,7 +51,7 @@ class Coordinator c where
   initialise :: MonadIO m => Config c -> m (Hook c)
 
   -- | Submit a task to the task queue.
-  --   If this task is already known to the system and not completed, then
+  --   If this task is not currently running, then
   --   it should not be re-added to the task queue as a result of this call.
   submitTask :: MonadIO m => Hook c -> TaskDescription -> m ()
 

--- a/funflow/src/Control/FunFlow/External/Coordinator.hs
+++ b/funflow/src/Control/FunFlow/External/Coordinator.hs
@@ -78,6 +78,9 @@ class Coordinator c where
   --   This should error for a task which is not running.
   updateTaskStatus :: MonadIO m => Hook c -> ContentHash -> TaskStatus -> m ()
 
+  -- | Remove all pending tasks from the queue.
+  dropTasks :: MonadIO m => Hook c -> m ()
+
 -- TH Splices
 
 makeLenses ''ExecutionInfo

--- a/funflow/src/Control/FunFlow/External/Coordinator/Memory.hs
+++ b/funflow/src/Control/FunFlow/External/Coordinator/Memory.hs
@@ -85,4 +85,3 @@ instance Coordinator MemoryCoordinator where
       if M.member tid eq
       then M.insert tid stat eq
       else error "Cannot update task status: task not executing."
-

--- a/funflow/src/Control/FunFlow/External/Coordinator/Memory.hs
+++ b/funflow/src/Control/FunFlow/External/Coordinator/Memory.hs
@@ -85,3 +85,6 @@ instance Coordinator MemoryCoordinator where
       if M.member tid eq
       then M.insert tid stat eq
       else error "Cannot update task status: task not executing."
+
+  dropTasks mh = liftIO . atomically $
+    modifyTVar (mh ^. mhTaskQueue) $ const []

--- a/funflow/src/Control/FunFlow/External/Coordinator/Redis.hs
+++ b/funflow/src/Control/FunFlow/External/Coordinator/Redis.hs
@@ -85,3 +85,9 @@ instance Coordinator Redis where
               _ <- R.set chashbytes (encode status)
               return . Just $ TaskDescription chash task
             Nothing    -> fail $ "Cannot decode content hash."
+
+  dropTasks conn = liftIO . R.runRedis conn $ do
+    job <- R.del ["jobs_queue"]
+    case job of
+      Left r -> fail $ "redis fail " ++ show r
+      Right _ -> return ()

--- a/funflow/src/Control/FunFlow/External/Coordinator/Redis.hs
+++ b/funflow/src/Control/FunFlow/External/Coordinator/Redis.hs
@@ -35,8 +35,8 @@ instance Coordinator Redis where
   -- | Create a redis connection
   initialise = liftIO . R.connect
 
-  submitTask conn td = unlessM (isInProgress conn $ td ^. tdOutput) $
-    liftIO $ do
+  submitTask conn td =
+    liftIO $
       R.runRedis conn $ do
         void $ R.rpush "jobs_queue" [encode (jid, td ^. tdTask)]
         void $ R.set jid (encode Pending)

--- a/funflow/src/Control/FunFlow/External/Coordinator/SQLite.hs
+++ b/funflow/src/Control/FunFlow/External/Coordinator/SQLite.hs
@@ -205,7 +205,7 @@ instance Coordinator SQLite where
 
   submitTask hook td = liftIO $
     withSQLite hook $ \conn -> SQL.executeNamed conn
-      "INSERT OR IGNORE INTO\
+      "INSERT OR REPLACE INTO\
       \  tasks (output, status, task)\
       \ VALUES\
       \  (:output, :status, :task)"

--- a/funflow/src/Control/FunFlow/External/Coordinator/SQLite.hs
+++ b/funflow/src/Control/FunFlow/External/Coordinator/SQLite.hs
@@ -295,3 +295,11 @@ instance Coordinator SQLite where
           Pending -> throwIO $ IllegalStatusUpdate output ts
           Running _ -> throwIO $ IllegalStatusUpdate output ts
         _ -> throwIO $ NonRunningTask output
+
+  dropTasks hook = liftIO $
+    withSQLite hook $ \conn ->
+      SQL.executeNamed conn
+        "DELETE FROM tasks\
+        \ WHERE\
+        \  status = :pending"
+        [ ":pending" SQL.:= SqlPending ]

--- a/funflow/test/FunFlow/ContentStore.hs
+++ b/funflow/test/FunFlow/ContentStore.hs
@@ -93,7 +93,7 @@ tests = testGroup "Content Store"
     withEmptyStore $ \store -> do
       hash <- contentHash ("test" :: String)
 
-      ContentStore.constructOrWait store hash >>= \case
+      ContentStore.constructOrAsync store hash >>= \case
         ContentStore.Pending _ ->
           assertFailure "missing already under construction"
         ContentStore.Complete _ ->
@@ -101,7 +101,7 @@ tests = testGroup "Content Store"
         ContentStore.Missing _ ->
           return ()
 
-      a <- ContentStore.constructOrWait store hash >>= \case
+      a <- ContentStore.constructOrAsync store hash >>= \case
         ContentStore.Missing _ -> do
           assertFailure "under construction still missing"
           undefined
@@ -129,7 +129,7 @@ tests = testGroup "Content Store"
       item'' <- wait b
       item'' @?= ContentStore.Completed item
 
-      ContentStore.constructOrWait store hash >>= \case
+      ContentStore.constructOrAsync store hash >>= \case
         ContentStore.Missing _ -> do
           assertFailure "complete still missing"
         ContentStore.Pending _ -> do
@@ -141,7 +141,7 @@ tests = testGroup "Content Store"
     withEmptyStore $ \store -> do
       hash <- contentHash ("test" :: String)
 
-      ContentStore.constructOrWait store hash >>= \case
+      ContentStore.constructOrAsync store hash >>= \case
         ContentStore.Pending _ ->
           assertFailure "missing already under construction"
         ContentStore.Complete _ ->
@@ -149,7 +149,7 @@ tests = testGroup "Content Store"
         ContentStore.Missing _ ->
           return ()
 
-      a <- ContentStore.constructOrWait store hash >>= \case
+      a <- ContentStore.constructOrAsync store hash >>= \case
         ContentStore.Missing _ -> do
           assertFailure "under construction still missing"
           undefined
@@ -177,7 +177,7 @@ tests = testGroup "Content Store"
       item'' <- wait b
       item'' @?= ContentStore.Failed
 
-      ContentStore.constructOrWait store hash >>= \case
+      ContentStore.constructOrAsync store hash >>= \case
         ContentStore.Pending _ -> do
           assertFailure "failed still under construction"
         ContentStore.Complete _ -> do


### PR DESCRIPTION
Now, the executor can assume that any task it is given is already marked
as pending and that this is the only executor executing that task.
The interpreter is now responsible for checking if the item is already
complete and marking it as pending if not.

Previously, a long lasting coordinator, like Redis or SQLite, stored a
completed task for a long time. If the content store item was removed in
the meantime, the coordinator would refuse to resubmit the task to
reconstruct that item.