### PR TITLE
Improve handling of failure of external tasks

### DIFF
--- a/funflow/src/Control/FunFlow/External.hs
+++ b/funflow/src/Control/FunFlow/External.hs
@@ -7,7 +7,6 @@
 -- | Definition of external tasks
 module Control.FunFlow.External where
 
-import           Control.Exception
 import           Control.FunFlow.ContentHashable (ContentHash, ContentHashable)
 import qualified Control.FunFlow.ContentStore    as CS
 import           Control.Lens.TH
@@ -16,7 +15,6 @@ import           Data.Semigroup
 import           Data.Store                      (Store)
 import           Data.String                     (IsString (..))
 import qualified Data.Text                       as T
-import           Data.Typeable                   (Typeable)
 import           GHC.Generics                    (Generic)
 import           Path
 import           System.Posix.Types              (CGid, CUid)
@@ -140,16 +138,6 @@ data TaskDescription = TaskDescription {
     _tdOutput :: ContentHash
   , _tdTask   :: ExternalTask
   } deriving (Generic, Show)
-
-data TaskError
-  = ExternalTaskFailed TaskDescription
-  deriving (Show, Typeable)
-instance Exception TaskError where
-  displayException (ExternalTaskFailed td) =
-    "External task failed to construct item '"
-    ++ show (_tdOutput td)
-    ++ "': "
-    ++ show (_tdTask td)
 
 makeLenses ''ExternalTask
 makeLenses ''TaskDescription


### PR DESCRIPTION
Extends the store to allow to attach metadata to items.
Keeps track of stdout/err of external tasks.
Attaches paths to stdout/err to `ExternalTaskFailed` exception on the flow interpreter side, if available.
This allows user code to log error messages of failed external tasks, even if those are executing on separate processes or even machines.