### PR TITLE
Executable permissions affects content hash

### DIFF
--- a/funflow/src/Control/FunFlow/ContentStore.hs
+++ b/funflow/src/Control/FunFlow/ContentStore.hs
@@ -482,7 +482,6 @@ markComplete store inHash = withStoreLock store $
       unsetWritableRecursively build
       -- XXX: Hashing large data can take some time,
       --   could we avoid locking the store for all that time?
-      -- XXX: Take executable bit of files into account.
       outHash <- contentHash (DirectoryContent build)
       let out = mkItemPath store outHash
           link' = mkCompletePath store inHash


### PR DESCRIPTION
A funflow might wish to copy an executable file into the store and then execute it as an external task. In such a case it is important that executable permissions are preserved and that the executable permissions affect the content hash such that an executable and a non-executable version of the same file are distinguished in the store.