### PR TITLE
Use hardlink lock instead of fcntl advisory lock

### DIFF
--- a/funflow/src/Control/FunFlow/ContentStore.hs
+++ b/funflow/src/Control/FunFlow/ContentStore.hs
@@ -590,8 +590,8 @@ listAliases store = withStoreLock store $
 ----------------------------------------------------------------------
 -- Internals
 
-lockPath :: Path Abs Dir -> Path Abs File
-lockPath = (</> [relfile|lock|])
+lockPath :: Path Abs Dir -> Path Abs Dir
+lockPath = (</> [reldir|lock|])
 
 dbPath :: Path Abs Dir -> Path Abs File
 dbPath = (</> [relfile|metadata.db|])

--- a/funflow/src/Control/FunFlow/External/Coordinator/SQLite.hs
+++ b/funflow/src/Control/FunFlow/External/Coordinator/SQLite.hs
@@ -185,7 +185,7 @@ instance Coordinator SQLite where
 
   initialise dir = liftIO $ do
     createDirIfMissing True dir
-    lock <- openLock (dir </> [relfile|lock|])
+    lock <- openLock (dir </> [reldir|lock|])
     withLock lock $ do
       conn <- SQL.open $ fromAbsFile (dir </> [relfile|db.sqlite|])
       SQL.execute_ conn

--- a/funflow/src/Control/FunFlow/Lock.hs
+++ b/funflow/src/Control/FunFlow/Lock.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
 -- | Thread and process write lock.
 --
 -- Allows synchronisation between threads and processes.
@@ -12,20 +15,23 @@ module Control.FunFlow.Lock
   , withLock
   ) where
 
-import           Control.Concurrent.MVar
+import           Control.Concurrent
 import           Control.Exception
-import           GHC.IO.Device           (SeekMode (AbsoluteSeek))
+import           Control.Monad           (unless)
+import           Network.HostName        (getHostName)
 import           Path
+import           Path.IO
 import           System.Posix.Files
 import           System.Posix.IO
-import           System.Posix.Types
+import           System.Posix.Process
+import           System.Random
 
 -- | Thread and process write lock.
 --
 -- Only ever have one 'Lock' object per lock file per process!
 data Lock = Lock
   { lockMVar :: MVar ()
-  , lockFd   :: Fd
+  , lockDir  :: Path Abs Dir
   }
 
 -- | Open the lock file and create a lock object.
@@ -33,13 +39,13 @@ data Lock = Lock
 -- This does not acquire the lock.
 --
 -- Only ever have one 'Lock' object per lock file per process!
-openLock :: Path Abs File -> IO Lock
-openLock lockFile = do
+openLock :: Path Abs Dir -> IO Lock
+openLock dir = do
   mvar <- newMVar ()
-  fd <- createFile (fromAbsFile $ lockFile) ownerWriteMode
+  createDirIfMissing True dir
   return $! Lock
     { lockMVar = mvar
-    , lockFd = fd
+    , lockDir = dir
     }
 
 -- | Close the lock file.
@@ -50,27 +56,45 @@ openLock lockFile = do
 closeLock :: Lock -> IO ()
 closeLock lock = do
   takeMVar (lockMVar lock)
-  closeFd (lockFd lock)
 
 -- | Acquire the lock for the duration of the given action and release after.
 withLock :: Lock -> IO a -> IO a
 withLock lock action =
   withMVar (lockMVar lock) $ \() ->
-    bracket_ (acquireFileLock $ lockFd lock) (releaseFileLock $ lockFd lock) $
+    bracket_ (acquireDirLock $ lockDir lock) (releaseDirLock $ lockDir lock) $
       action
 
 ----------------------------------------------------------------------
 -- Internals
 
-makeLockDesc :: LockRequest -> FileLock
-makeLockDesc req = (req, AbsoluteSeek, COff 0, COff 1)
+getUniqueFileName :: IO (Path Rel File)
+getUniqueFileName = do
+  hostName <- getHostName
+  pid <- getProcessID
+  parseRelFile $ hostName ++ show pid
 
-acquireFileLock :: Fd -> IO ()
-acquireFileLock fd = do
-  let lockDesc = makeLockDesc WriteLock
-  waitToSetLock fd lockDesc
+lockFileName :: Path Rel File
+lockFileName = [relfile|lock|]
 
-releaseFileLock :: Fd -> IO ()
-releaseFileLock fd = do
-  let lockDesc = makeLockDesc Unlock
-  setLock fd lockDesc
+acquireDirLock :: Path Abs Dir -> IO ()
+acquireDirLock dir = do
+  file <- getUniqueFileName
+  let path = dir </> file
+  fd <- createFile (fromAbsFile path) ownerWriteMode
+  closeFd fd
+  r <- try $ createLink (fromAbsFile path) (fromAbsFile $ dir </> lockFileName)
+  case r of
+    Right () -> return ()
+    Left (_::IOError) -> do
+      count <- linkCount <$> getFileStatus (fromAbsFile path)
+      unless (count == 2) $ do
+        delay <- randomRIO (50000, 100000)
+        threadDelay delay
+        acquireDirLock dir
+
+releaseDirLock :: Path Abs Dir -> IO ()
+releaseDirLock dir = do
+  file <- getUniqueFileName
+  let path = dir </> file
+  removeLink (fromAbsFile $ dir </> lockFileName)
+  removeLink (fromAbsFile path)


### PR DESCRIPTION
It turns out that fcntl write locks are unreliable on certain network
file systems. This implements exclusive file locks using hardlinks as
described in the man page of `open (2)` in the paragraph under `O_EXCL`.