### PR TITLE
Build test dependencies in dep build step.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
           command: stack setup
       - run:
           name: Building dependencies
-          command: stack build --only-snapshot --prefetch
+          command: stack test --only-snapshot --prefetch
       - save_cache:
           paths:
             - "~/.stack"


### PR DESCRIPTION
This should shorten the time it takes to build the tests each CI run.