### PR TITLE
Fix some issues with pending actions

### DIFF
--- a/funflow/src/Control/Arrow/Async.hs
+++ b/funflow/src/Control/Arrow/Async.hs
@@ -27,10 +27,10 @@ instance MonadBaseControl IO m => Arrow (AsyncA m) where
   arr f = AsyncA (return . f)
   first (AsyncA f) = AsyncA (\ ~(b,d) -> f b >>= \c -> return (c,d))
   second (AsyncA f) = AsyncA (\ ~(d,b) -> f b >>= \c -> return (d,c))
-  (AsyncA f) *** (AsyncA g) = AsyncA $ \ ~(a,b) -> do
-    c <- async $ f a
-    d <- async $ g b
-    waitBoth c d
+  (AsyncA f) *** (AsyncA g) = AsyncA $ \ ~(a,b) ->
+    withAsync (f a) $ \c ->
+      withAsync (g b) $ \d ->
+        waitBoth c d
 
 instance MonadBaseControl IO m => ArrowChoice (AsyncA m) where
     left f = f +++ arr id

--- a/funflow/src/Control/Arrow/Async.hs
+++ b/funflow/src/Control/Arrow/Async.hs
@@ -12,6 +12,7 @@ import           Control.Category
 import           Control.Concurrent.Async.Lifted
 import           Control.Monad.Catch             (Exception, MonadCatch)
 import qualified Control.Monad.Catch             as Monad.Catch
+import           Control.Monad.Trans.Class       (MonadTrans, lift)
 import           Control.Monad.Trans.Control     (MonadBaseControl)
 import           Prelude                         hiding (id, (.))
 
@@ -41,3 +42,9 @@ instance (Exception ex, MonadBaseControl IO m, MonadCatch m)
   => ArrowError ex (AsyncA m) where
     AsyncA arr1 `catch` AsyncA arr2 = AsyncA $ \x ->
       arr1 x `Monad.Catch.catch` curry arr2 x
+
+-- | Lift an AsyncA through a monad transformer of the underlying monad.
+liftAsyncA :: (MonadTrans t, Monad m)
+           => AsyncA m i o
+           -> AsyncA (t m) i o
+liftAsyncA (AsyncA f) = AsyncA $ \i -> lift (f i)

--- a/funflow/src/Control/FunFlow/ContentStore.hs
+++ b/funflow/src/Control/FunFlow/ContentStore.hs
@@ -91,7 +91,6 @@ module Control.FunFlow.ContentStore
   , getMetadataFile
 
   -- * Accessors
-  , buildPath
   , itemHash
   , itemPath
   , contentPath
@@ -307,12 +306,6 @@ newtype Alias = Alias { unAlias :: T.Text }
 -- | The root directory of the store.
 root :: ContentStore -> Path Abs Dir
 root = storeRoot
-
--- | Path of the build directory of a pending item.
---
--- Beware, this does not check whether the item is actually pending.
-buildPath :: ContentStore -> ContentHash -> Path Abs Dir
-buildPath = mkPendingPath
 
 -- | The store path of a completed item.
 itemPath :: ContentStore -> Item -> Path Abs Dir

--- a/funflow/src/Control/FunFlow/Exec/Simple.hs
+++ b/funflow/src/Control/FunFlow/Exec/Simple.hs
@@ -14,36 +14,42 @@ module Control.FunFlow.Exec.Simple
   , withSimpleLocalRunner
   ) where
 
-import           Control.Arrow (returnA)
+import           Control.Arrow                               (returnA)
 import           Control.Arrow.Async
-import           Control.Arrow.Free                   (eval, type (~>))
-import           Control.Concurrent.Async             (withAsync)
+import           Control.Arrow.Free                          (eval, type (~>))
+import           Control.Concurrent.Async                    (withAsync)
 import           Control.FunFlow.Base
 import           Control.FunFlow.ContentHashable
-import qualified Control.FunFlow.ContentStore         as CS
+import qualified Control.FunFlow.ContentStore                as CS
 import           Control.FunFlow.External
 import           Control.FunFlow.External.Coordinator
 import           Control.FunFlow.External.Coordinator.Memory
-import           Control.FunFlow.External.Executor    (executeLoop)
-import           Control.Monad.Catch                  ( SomeException
-                                                      , Exception, onException
-                                                      , throwM, try)
-import qualified Data.ByteString                      as BS
+import           Control.FunFlow.External.Executor           (executeLoop)
+import           Control.Monad.Catch                         (Exception,
+                                                              SomeException,
+                                                              bracket,
+                                                              onException,
+                                                              throwM, try)
+import           Control.Monad.IO.Class                      (liftIO)
+import           Control.Monad.Trans.Class                   (lift)
+import qualified Data.ByteString                             as BS
 import           Data.Void
+import           Katip
 import           Path
+import           System.IO                                   (stderr)
 
 -- | Simple evaulation of a flow
 runFlowEx :: forall c eff ex a b. (Coordinator c, Exception ex)
           => c
           -> Config c
           -> CS.ContentStore
-          -> (eff ~> AsyncA IO) -- ^ Natural transformation from wrapped effects
+          -> (eff ~> AsyncA (KatipContextT IO)) -- ^ Natural transformation from wrapped effects
           -> Int -- ^ Flow configuration identity. This forms part of the caching
                  --   system and is used to disambiguate the same flow run in
                  --   multiple configurations.
           -> Flow eff ex a b
           -> a
-          -> IO b
+          -> KatipContextT IO b
 runFlowEx _ cfg store runWrapped confIdent flow input = do
     hook <- initialise cfg
     runAsyncA (eval (runFlow' hook) flow) input
@@ -51,20 +57,20 @@ runFlowEx _ cfg store runWrapped confIdent flow input = do
     simpleOutPath item = toFilePath
       $ CS.itemPath store item </> [relfile|out|]
     withStoreCache :: forall i o. Cacher i o
-                   -> AsyncA IO i o -> AsyncA IO i o
+                   -> AsyncA (KatipContextT IO) i o -> AsyncA (KatipContextT IO) i o
     withStoreCache NoCache f = f
     withStoreCache c f = let
         chashOf i = cacherKey c confIdent i
-        checkStore = AsyncA $ \chash -> do
+        checkStore = AsyncA $ \chash ->
           CS.constructOrWait store chash >>= \case
             CS.Pending void -> absurd void
             CS.Complete item -> do
-              bs <- BS.readFile $ simpleOutPath item
+              bs <- liftIO . BS.readFile $ simpleOutPath item
               return . Right . cacherReadValue c $ bs
             CS.Missing fp -> return $ Left fp
         writeStore = AsyncA $ \(chash, fp, res) ->
           do
-             BS.writeFile (toFilePath $ fp </> [relfile|out|])
+             liftIO $ BS.writeFile (toFilePath $ fp </> [relfile|out|])
                          . cacherStoreValue c $ res
              _ <- CS.markComplete store chash
              return res
@@ -79,13 +85,13 @@ runFlowEx _ cfg store runWrapped confIdent flow input = do
             res <- f -< i
             writeStore -< (chash, fp, res)
 
-    runFlow' :: Hook c -> Flow' eff a1 b1 -> AsyncA IO a1 b1
+    runFlow' :: Hook c -> Flow' eff a1 b1 -> AsyncA (KatipContextT IO) a1 b1
     runFlow' _ (Step props f) = withStoreCache (cache props)
-      $ AsyncA $ \x -> return $ f x
+      . AsyncA $ \x -> return $ f x
     runFlow' _ (StepIO props f) = withStoreCache (cache props)
-      $ AsyncA f
+      . liftAsyncA $ AsyncA f
     runFlow' po (External toTask) = AsyncA $ \x -> do
-      chash <- contentHash (x, toTask x)
+      chash <- liftIO $ contentHash (x, toTask x)
       CS.lookup store chash >>= \case
         -- The item in question is already in the store. No need to submit a task.
         CS.Complete item -> return item
@@ -117,23 +123,39 @@ runFlowEx _ cfg store runWrapped confIdent flow input = do
               mbStderr <- CS.getMetadataFile store chash [relfile|stderr|]
               throwM $ ExternalTaskFailed td ti mbStdout mbStderr
     runFlow' _ (PutInStore f) = AsyncA $ \x -> do
-      chash <- contentHash x
+      chash <- liftIO $ contentHash x
       CS.constructOrWait store chash >>= \case
         CS.Pending void -> absurd void
         CS.Complete item -> return item
         CS.Missing fp ->
           do
-            f fp x
+            liftIO $ f fp x
             CS.markComplete store chash
           `onException`
           CS.removeFailed store chash
     runFlow' _ (GetFromStore f) = AsyncA $ \case
-      CS.All item -> f $ CS.itemPath store item
-      item CS.:</> path -> f $ CS.itemPath store item </> path
-    runFlow' _ (InternalManipulateStore f) = AsyncA $ \i -> f store i
+      CS.All item -> lift . f $ CS.itemPath store item
+      item CS.:</> path -> lift . f $ CS.itemPath store item </> path
+    runFlow' _ (InternalManipulateStore f) = AsyncA $ \i ->lift $ f store i
     runFlow' _ (Wrapped props w) = withStoreCache (cache props)
       $ runWrapped w
 
+-- | Run a flow in a logging context.
+runFlowLog :: forall c eff ex a b. (Coordinator c, Exception ex)
+           => c
+           -> Config c
+           -> CS.ContentStore
+           -> (eff ~> AsyncA (KatipContextT IO)) -- ^ Natural transformation from wrapped effects
+           -> Int -- ^ Flow configuration identity. This forms part of the caching
+                 --   system and is used to disambiguate the same flow run in
+                 --   multiple configurations.
+           -> Flow eff ex a b
+           -> a
+           -> KatipContextT IO (Either ex b)
+runFlowLog c cfg store runWrapped confIdent flow input =
+  try $ runFlowEx c cfg store runWrapped confIdent flow input
+
+-- | Run a flow, discarding all logging.
 runFlow :: forall c eff ex a b. (Coordinator c, Exception ex)
         => c
         -> Config c
@@ -145,9 +167,12 @@ runFlow :: forall c eff ex a b. (Coordinator c, Exception ex)
         -> Flow eff ex a b
         -> a
         -> IO (Either ex b)
-runFlow c cfg store runWrapped confIdent flow input =
-  try $ runFlowEx c cfg store runWrapped confIdent flow input
+runFlow c cfg store runWrapped confIdent flow input = do
+  le <- initLogEnv "funflow" "production"
+  runKatipContextT le () "runFlow"
+    $ runFlowLog c cfg store (liftAsyncA . runWrapped) confIdent flow input
 
+-- | Run a simple flow. Logging will be sent to stderr
 runSimpleFlow :: forall c a b. (Coordinator c)
         => c
         -> Config c
@@ -155,8 +180,15 @@ runSimpleFlow :: forall c a b. (Coordinator c)
         -> SimpleFlow a b
         -> a
         -> IO (Either SomeException b)
-runSimpleFlow c ccfg store flow input =
-  runFlow c ccfg store runNoEffect 12345 flow input
+runSimpleFlow c ccfg store flow input = do
+  handleScribe <- mkHandleScribe ColorIfTerminal stderr InfoS V2
+  let mkLogEnv = registerScribe "stderr" handleScribe defaultScribeSettings =<< initLogEnv "funflow" "production"
+  bracket mkLogEnv closeScribes $ \le -> do
+    let initialContext = ()
+        initialNamespace = "executeLoop"
+
+    runKatipContextT le initialContext initialNamespace
+      $ runFlowLog c ccfg store runNoEffect 12345 flow input
 
 -- | Create a full pipeline runner locally. This includes an executor for
 --   executing external tasks.

--- a/funflow/src/Control/FunFlow/Exec/Simple.hs
+++ b/funflow/src/Control/FunFlow/Exec/Simple.hs
@@ -101,6 +101,8 @@ runFlowEx _ cfg store runWrapped confIdent flow input = do
           -- Task is already known to the coordinator. Most likely something is
           -- running this task. Just wait for it.
           KnownTask _ -> wait chash (TaskDescription chash (toTask x))
+        -- Nothing in the store. Submit and run.
+        CS.Missing _ -> submitAndWait chash (TaskDescription chash (toTask x))
       where
         submitAndWait chash td = do
           submitTask po td

--- a/funflow/src/Control/FunFlow/External/Executor.hs
+++ b/funflow/src/Control/FunFlow/External/Executor.hs
@@ -49,62 +49,66 @@ data ExecutionResult =
 -- | Execute an individual task.
 execute :: CS.ContentStore -> TaskDescription -> KatipContextT IO ExecutionResult
 execute store td = do
-  (fpOut, hOut) <- lift $
-    CS.createMetadataFile store (td ^. tdOutput) [relfile|stdout|]
-  (fpErr, hErr) <- lift $
-    CS.createMetadataFile store (td ^. tdOutput) [relfile|stderr|]
-  let
-    withFollowOutput m
-      | td ^. tdTask . etWriteToStdOut
-      = withAsync (followFile fpErr stderr) $ \_ -> m
-      | otherwise
-      = withAsync (followFile fpErr stderr) $ \_ ->
-        withAsync (followFile fpOut stdout) $ \_ -> m
-    fp = CS.buildPath store (td ^. tdOutput)
-    cmd = T.unpack $ td ^. tdTask . etCommand
-    procSpec params = (proc cmd $ T.unpack <$> params) {
-        cwd = Just (fromAbsDir fp)
-      , close_fds = True
-      , std_err = UseHandle hErr
-      , std_out = UseHandle hOut
-      }
-    convParam = ConvParam
-      { convPath = pure . CS.itemPath store
-      , convEnv = \e -> T.pack <$> MaybeT (getEnv $ T.unpack e)
-      , convUid = lift getEffectiveUserID
-      , convGid = lift getEffectiveGroupID
-      , convOut = pure fp
-      }
-  mbParams <- lift $ runMaybeT $
-    traverse (paramToText convParam) (td ^. tdTask . etParams)
-  params <- case mbParams of
-    Nothing     -> fail "A parameter was not ready"
-    Just params -> return params
+  instruction <- lift $ CS.constructIfMissing store (td ^. tdOutput)
+  case instruction of
+    CS.Pending () -> return AlreadyRunning
+    CS.Complete _ -> return Cached
+    CS.Missing fp -> do
+      (fpOut, hOut) <- lift $
+        CS.createMetadataFile store (td ^. tdOutput) [relfile|stdout|]
+      (fpErr, hErr) <- lift $
+        CS.createMetadataFile store (td ^. tdOutput) [relfile|stderr|]
+      let
+        withFollowOutput m
+          | td ^. tdTask . etWriteToStdOut
+          = withAsync (followFile fpErr stderr) $ \_ -> m
+          | otherwise
+          = withAsync (followFile fpErr stderr) $ \_ ->
+            withAsync (followFile fpOut stdout) $ \_ -> m
+        cmd = T.unpack $ td ^. tdTask . etCommand
+        procSpec params = (proc cmd $ T.unpack <$> params) {
+            cwd = Just (fromAbsDir fp)
+          , close_fds = True
+          , std_err = UseHandle hErr
+          , std_out = UseHandle hOut
+          }
+        convParam = ConvParam
+          { convPath = pure . CS.itemPath store
+          , convEnv = \e -> T.pack <$> MaybeT (getEnv $ T.unpack e)
+          , convUid = lift getEffectiveUserID
+          , convGid = lift getEffectiveGroupID
+          , convOut = pure fp
+          }
+      mbParams <- lift $ runMaybeT $
+        traverse (paramToText convParam) (td ^. tdTask . etParams)
+      params <- case mbParams of
+        Nothing     -> fail "A parameter was not ready"
+        Just params -> return params
 
-  start <- lift $ getTime Monotonic
-  let theProc = procSpec params
-  katipAddNamespace "process" . katipAddContext (sl "processId" $ show theProc) $ do
-    $(logTM) InfoS "Executing"
-    mp <- lift $ try $ createProcess theProc
-    case mp of
-      Left (ex :: IOException) -> do
-        $(logTM) WarningS . ls $ "Failed: " ++ show ex
-        lift $ CS.removeFailed store (td ^. tdOutput)
-        return $ Failure (diffTimeSpec start start) 2
-      Right (_, _, _, ph) -> lift $
-        -- Error output should be displayed on our stderr stream
-        withFollowOutput $ do
-          exitCode <- waitForProcess ph
-          end <- getTime Monotonic
-          case exitCode of
-            ExitSuccess   -> do
-              when (td ^. tdTask . etWriteToStdOut) $
-                copyFile fpOut (fp </> [relfile|out|])
-              _ <- CS.markComplete store (td ^. tdOutput)
-              return $ Success (diffTimeSpec start end)
-            ExitFailure i -> do
-              CS.removeFailed store (td ^. tdOutput)
-              return $ Failure (diffTimeSpec start end) i
+      start <- lift $ getTime Monotonic
+      let theProc = procSpec params
+      katipAddNamespace "process" . katipAddContext (sl "processId" $ show theProc) $ do
+        $(logTM) InfoS "Executing"
+        mp <- lift $ try $ createProcess theProc
+        case mp of
+          Left (ex :: IOException) -> do
+            $(logTM) WarningS . ls $ "Failed: " ++ show ex
+            lift $ CS.removeFailed store (td ^. tdOutput)
+            return $ Failure (diffTimeSpec start start) 2
+          Right (_, _, _, ph) -> lift $
+            -- Error output should be displayed on our stderr stream
+            withFollowOutput $ do
+              exitCode <- waitForProcess ph
+              end <- getTime Monotonic
+              case exitCode of
+                ExitSuccess   -> do
+                  when (td ^. tdTask . etWriteToStdOut) $
+                    copyFile fpOut (fp </> [relfile|out|])
+                  _ <- CS.markComplete store (td ^. tdOutput)
+                  return $ Success (diffTimeSpec start end)
+                ExitFailure i -> do
+                  CS.removeFailed store (td ^. tdOutput)
+                  return $ Failure (diffTimeSpec start end) i
 
 -- | Execute tasks forever
 executeLoop :: forall c. Coordinator c


### PR DESCRIPTION
This PR tries to clear up some issues that could occur with pending actions getting left behind. In particular, where there was an error during a parallel step, only one pending action would be cleaned up correctly.

Individual commits should have more context in.