### PR TITLE
Exception safe executor

### DIFF
--- a/funflow-checkpoints/funflow-checkpoints.cabal
+++ b/funflow-checkpoints/funflow-checkpoints.cabal
@@ -36,5 +36,6 @@ Test-suite unit-tests
                     , funflow
                     , funflow-checkpoints
                     , path-io
+                    , safe-exceptions
                     , tasty
                     , tasty-hunit

--- a/funflow-checkpoints/test/Tests.hs
+++ b/funflow-checkpoints/test/Tests.hs
@@ -7,7 +7,7 @@
 import           Control.Arrow
 import           Control.Arrow.Free
 import           Control.Category
-import           Control.Exception
+import           Control.Exception.Safe
 import           Control.FunFlow
 import           Control.FunFlow.Checkpoints
 import           Control.Monad               (guard)

--- a/funflow-jobs/src/Control/FunFlow/Jobs/Redis.hs
+++ b/funflow-jobs/src/Control/FunFlow/Jobs/Redis.hs
@@ -21,7 +21,6 @@ module Control.FunFlow.Jobs.Redis
   )  where
 
 import           Control.Concurrent
-import           Control.Exception
 import           Control.FunFlow
 import           Control.FunFlow.Utils
 import           Control.Lens                hiding (argument)

--- a/funflow/TestFunflow.hs
+++ b/funflow/TestFunflow.hs
@@ -4,12 +4,11 @@
 
 import           Control.Arrow
 import           Control.Arrow.Free
+import           Control.Exception.Safe
 import           Control.FunFlow
 import qualified Control.FunFlow.ContentStore                as CS
 import           Control.FunFlow.External.Coordinator.Memory
 import           Control.FunFlow.Pretty
-import           Control.Monad.Catch                         (SomeException,
-                                                              toException)
 import           Data.Monoid                                 ((<>))
 import           Path.IO
 

--- a/funflow/funflow.cabal
+++ b/funflow/funflow.cabal
@@ -81,6 +81,7 @@ Library
                , pretty
                , process
                , random
+               , safe-exceptions
                , scientific
                , sqlite-simple
                , stm
@@ -129,7 +130,7 @@ Test-suite test-funflow
                      , path
                      , path-io
                      , text
-                     , exceptions
+                     , safe-exceptions
                      , unix
 
 Test-suite unit-tests

--- a/funflow/src/Control/Arrow/Async.hs
+++ b/funflow/src/Control/Arrow/Async.hs
@@ -10,8 +10,8 @@ import           Control.Arrow
 import           Control.Arrow.Free              (ArrowError (..))
 import           Control.Category
 import           Control.Concurrent.Async.Lifted
-import           Control.Monad.Catch             (Exception, MonadCatch)
-import qualified Control.Monad.Catch             as Monad.Catch
+import           Control.Exception.Safe          (Exception, MonadCatch)
+import qualified Control.Exception.Safe
 import           Control.Monad.Trans.Class       (MonadTrans, lift)
 import           Control.Monad.Trans.Control     (MonadBaseControl)
 import           Prelude                         hiding (id, (.))
@@ -41,7 +41,7 @@ instance MonadBaseControl IO m => ArrowChoice (AsyncA m) where
 instance (Exception ex, MonadBaseControl IO m, MonadCatch m)
   => ArrowError ex (AsyncA m) where
     AsyncA arr1 `catch` AsyncA arr2 = AsyncA $ \x ->
-      arr1 x `Monad.Catch.catch` curry arr2 x
+      arr1 x `Control.Exception.Safe.catch` curry arr2 x
 
 -- | Lift an AsyncA through a monad transformer of the underlying monad.
 liftAsyncA :: (MonadTrans t, Monad m)

--- a/funflow/src/Control/Arrow/Free.hs
+++ b/funflow/src/Control/Arrow/Free.hs
@@ -30,8 +30,8 @@ module Control.Arrow.Free
 
 import           Control.Arrow
 import           Control.Category
-import           Control.Monad.Catch (Exception, MonadCatch)
-import qualified Control.Monad.Catch as Monad.Catch
+import           Control.Exception.Safe (Exception, MonadCatch)
+import qualified Control.Exception.Safe
 import           Data.Bool           (Bool)
 import           Data.Constraint     (Constraint, Dict (..), mapDict, weaken1,
                                       weaken2)
@@ -148,7 +148,7 @@ class ArrowError ex a where
 instance (Arrow (Kleisli m), Exception ex, MonadCatch m)
   => ArrowError ex (Kleisli m) where
     Kleisli arr1 `catch` Kleisli arr2 = Kleisli $ \x ->
-      arr1 x `Monad.Catch.catch` curry arr2 x
+      arr1 x `Control.Exception.Safe.catch` curry arr2 x
 
 newtype ErrorChoice ex eff a b = ErrorChoice {
   runErrorChoice :: forall ac. (ArrowChoice ac, ArrowError ex ac)

--- a/funflow/src/Control/FunFlow/Base.hs
+++ b/funflow/src/Control/FunFlow/Base.hs
@@ -11,7 +11,7 @@ module Control.FunFlow.Base where
 
 import           Control.Arrow                   (Kleisli(..))
 import           Control.Arrow.Free
-import           Control.Exception               (SomeException)
+import           Control.Exception.Safe          (SomeException)
 import           Control.FunFlow.ContentHashable
 import qualified Control.FunFlow.ContentStore    as CS
 import           Control.FunFlow.Diagram

--- a/funflow/src/Control/FunFlow/ContentStore.hs
+++ b/funflow/src/Control/FunFlow/ContentStore.hs
@@ -117,14 +117,14 @@ import           Control.Arrow                       (second)
 import           Control.Concurrent                  (threadDelay)
 import           Control.Concurrent.Async
 import           Control.Concurrent.MVar
-import           Control.Exception                   (Exception, bracket_,
+import           Control.Exception.Safe              (Exception, MonadMask,
+                                                      bracket, bracket_,
                                                       displayException, throwIO)
 import           Control.FunFlow.ContentStore.Notify
 import           Control.FunFlow.Orphans             ()
 import           Control.Lens
 import           Control.Monad                       (forever, unless, void,
                                                       when, (<=<), (>=>))
-import           Control.Monad.Catch                 (MonadMask, bracket)
 import           Control.Monad.IO.Class              (MonadIO, liftIO)
 import           Crypto.Hash                         (hashUpdate)
 import           Data.Aeson                          (FromJSON, ToJSON)

--- a/funflow/src/Control/FunFlow/ContentStore/Notify/BSD.hs
+++ b/funflow/src/Control/FunFlow/ContentStore/Notify/BSD.hs
@@ -13,7 +13,7 @@ module Control.FunFlow.ContentStore.Notify.BSD
 
 import           Control.Concurrent
 import           Control.Concurrent.Async
-import           Control.Exception
+import           Control.Exception.Safe
 import           Control.Monad
 import           Data.Typeable
 import           Foreign.Ptr

--- a/funflow/src/Control/FunFlow/ContentStore/Notify/Linux.hs
+++ b/funflow/src/Control/FunFlow/ContentStore/Notify/Linux.hs
@@ -11,7 +11,7 @@ module Control.FunFlow.ContentStore.Notify.Linux
   , removeDirWatch
   ) where
 
-import           Control.Exception (catch)
+import           Control.Exception.Safe (catch)
 import           System.INotify
 
 type Notifier = INotify

--- a/funflow/src/Control/FunFlow/Exec/Simple.hs
+++ b/funflow/src/Control/FunFlow/Exec/Simple.hs
@@ -26,7 +26,7 @@ import           Control.FunFlow.External
 import           Control.FunFlow.External.Coordinator
 import           Control.FunFlow.External.Coordinator.Memory
 import           Control.FunFlow.External.Executor           (executeLoop)
-import           Control.Monad.Catch                         (Exception,
+import           Control.Exception.Safe                      (Exception,
                                                               SomeException,
                                                               bracket,
                                                               onException,

--- a/funflow/src/Control/FunFlow/External/Coordinator.hs
+++ b/funflow/src/Control/FunFlow/External/Coordinator.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE TypeFamilyDependencies     #-}
 module Control.FunFlow.External.Coordinator where
 
-import           Control.Exception
+import           Control.Exception.Safe
 import           Control.FunFlow.ContentHashable (ContentHash)
 import           Control.FunFlow.External
 import           Control.Lens

--- a/funflow/src/Control/FunFlow/External/Coordinator/SQLite.hs
+++ b/funflow/src/Control/FunFlow/External/Coordinator/SQLite.hs
@@ -9,7 +9,7 @@ module Control.FunFlow.External.Coordinator.SQLite
   ) where
 
 import           Control.Concurrent                   (threadDelay)
-import           Control.Exception
+import           Control.Exception.Safe
 import           Control.FunFlow.ContentHashable
 import           Control.FunFlow.External
 import           Control.FunFlow.External.Coordinator

--- a/funflow/src/Control/FunFlow/External/Executor.hs
+++ b/funflow/src/Control/FunFlow/External/Executor.hs
@@ -48,66 +48,59 @@ data ExecutionResult =
 -- | Execute an individual task.
 execute :: CS.ContentStore -> TaskDescription -> KatipContextT IO ExecutionResult
 execute store td = do
-  instruction <- lift $ CS.constructIfMissing store (td ^. tdOutput)
-  case instruction of
-    CS.Pending () -> return AlreadyRunning
-    CS.Complete _ -> return Cached
-    CS.Missing fp -> do
-      (fpOut, hOut) <- lift $
-        CS.createMetadataFile store (td ^. tdOutput) [relfile|stdout|]
-      (fpErr, hErr) <- lift $
-        CS.createMetadataFile store (td ^. tdOutput) [relfile|stderr|]
-      let
-        withFollowOutput m
-          | td ^. tdTask . etWriteToStdOut
-          = withAsync (followFile fpErr stderr) $ \_ -> m
-          | otherwise
-          = withAsync (followFile fpErr stderr) $ \_ ->
-            withAsync (followFile fpOut stdout) $ \_ -> m
-        cmd = T.unpack $ td ^. tdTask . etCommand
-        procSpec params = (proc cmd $ T.unpack <$> params) {
-            cwd = Just (fromAbsDir fp)
-          , close_fds = True
-          , std_err = UseHandle hErr
-          , std_out = UseHandle hOut
-          }
-        convParam = ConvParam
-          { convPath = pure . CS.itemPath store
-          , convEnv = \e -> T.pack <$> MaybeT (getEnv $ T.unpack e)
-          , convUid = lift getEffectiveUserID
-          , convGid = lift getEffectiveGroupID
-          , convOut = pure fp
-          }
-      mbParams <- lift $ runMaybeT $
-        traverse (paramToText convParam) (td ^. tdTask . etParams)
-      params <- case mbParams of
-        Nothing     -> fail "A parameter was not ready"
-        Just params -> return params
+  status <- CS.withConstructIfMissing store (td ^. tdOutput) $ \fp -> do
+    (fpOut, hOut) <- lift $
+      CS.createMetadataFile store (td ^. tdOutput) [relfile|stdout|]
+    (fpErr, hErr) <- lift $
+      CS.createMetadataFile store (td ^. tdOutput) [relfile|stderr|]
+    let
+      withFollowOutput m
+        | td ^. tdTask . etWriteToStdOut
+        = withAsync (followFile fpErr stderr) $ \_ -> m
+        | otherwise
+        = withAsync (followFile fpErr stderr) $ \_ ->
+          withAsync (followFile fpOut stdout) $ \_ -> m
+      cmd = T.unpack $ td ^. tdTask . etCommand
+      procSpec params = (proc cmd $ T.unpack <$> params)
+        { cwd = Just (fromAbsDir fp)
+        , close_fds = True
+        , std_err = UseHandle hErr
+        , std_out = UseHandle hOut
+        }
+      convParam = ConvParam
+        { convPath = pure . CS.itemPath store
+        , convEnv = \e -> T.pack <$> MaybeT (getEnv $ T.unpack e)
+        , convUid = lift getEffectiveUserID
+        , convGid = lift getEffectiveGroupID
+        , convOut = pure fp
+        }
+    mbParams <- lift $ runMaybeT $
+      traverse (paramToText convParam) (td ^. tdTask . etParams)
+    params <- case mbParams of
+      Nothing     -> fail "A parameter was not ready"
+      Just params -> return params
 
-      start <- lift $ getTime Monotonic
-      let theProc = procSpec params
-      katipAddNamespace "process" . katipAddContext (sl "processId" $ show theProc) $ do
-        $(logTM) InfoS "Executing"
-        mp <- lift $ try $ createProcess theProc
-        case mp of
-          Left (ex :: IOException) -> do
-            $(logTM) WarningS . ls $ "Failed: " ++ show ex
-            lift $ CS.removeFailed store (td ^. tdOutput)
-            return $ Failure (diffTimeSpec start start) 2
-          Right (_, _, _, ph) -> lift $
-            -- Error output should be displayed on our stderr stream
-            withFollowOutput $ do
-              exitCode <- waitForProcess ph
-              end <- getTime Monotonic
-              case exitCode of
-                ExitSuccess   -> do
-                  when (td ^. tdTask . etWriteToStdOut) $
-                    copyFile fpOut (fp </> [relfile|out|])
-                  _ <- CS.markComplete store (td ^. tdOutput)
-                  return $ Success (diffTimeSpec start end)
-                ExitFailure i -> do
-                  CS.removeFailed store (td ^. tdOutput)
-                  return $ Failure (diffTimeSpec start end) i
+    start <- lift $ getTime Monotonic
+    let theProc = procSpec params
+    katipAddNamespace "process" . katipAddContext (sl "processId" $ show theProc) $ do
+      $(logTM) InfoS "Executing"
+      lift $ withCreateProcess theProc $ \_ _ _ ph ->
+        -- Error output should be displayed on our stderr stream
+        withFollowOutput $ do
+          exitCode <- waitForProcess ph
+          end <- getTime Monotonic
+          case exitCode of
+            ExitSuccess   -> do
+              when (td ^. tdTask . etWriteToStdOut) $
+                copyFile fpOut (fp </> [relfile|out|])
+              return $ Right (diffTimeSpec start end)
+            ExitFailure i ->
+              return $ Left (diffTimeSpec start end, i)
+  case status of
+    CS.Missing (t, ec) -> return (Failure t ec)
+    CS.Pending () -> return AlreadyRunning
+    CS.Complete (Nothing, _) -> return Cached
+    CS.Complete (Just t, _) -> return (Success t)
 
 -- | Execute tasks forever
 executeLoop :: forall c. Coordinator c

--- a/funflow/src/Control/FunFlow/External/Executor.hs
+++ b/funflow/src/Control/FunFlow/External/Executor.hs
@@ -7,14 +7,13 @@
 module Control.FunFlow.External.Executor where
 
 import           Control.Concurrent                   (threadDelay)
-import           Control.Exception                    (IOException)
+import           Control.Exception.Safe
 import           Control.Concurrent.Async
 import qualified Control.FunFlow.ContentStore         as CS
 import           Control.FunFlow.External
 import           Control.FunFlow.External.Coordinator
 import           Control.Lens
 import           Control.Monad                        (forever, when)
-import           Control.Monad.Catch
 import           Control.Monad.Trans                  (lift)
 import           Control.Monad.Trans.Maybe
 import qualified Data.ByteString                      as BS

--- a/funflow/src/Control/FunFlow/Lock.hs
+++ b/funflow/src/Control/FunFlow/Lock.hs
@@ -16,7 +16,7 @@ module Control.FunFlow.Lock
   ) where
 
 import           Control.Concurrent
-import           Control.Exception
+import           Control.Exception.Safe
 import           Control.Monad           (unless)
 import           Network.HostName        (getHostName)
 import           Path

--- a/funflow/src/Control/FunFlow/Steps.hs
+++ b/funflow/src/Control/FunFlow/Steps.hs
@@ -41,7 +41,7 @@ where
 
 import           Control.Arrow
 import           Control.Arrow.Free              (catch)
-import           Control.Exception               (Exception)
+import           Control.Exception.Safe          (Exception, throwM)
 import           Control.FunFlow.Base            (SimpleFlow)
 import           Control.FunFlow.Class
 import           Control.FunFlow.ContentHashable (ContentHashable,
@@ -50,7 +50,6 @@ import           Control.FunFlow.ContentHashable (ContentHashable,
 import           Control.FunFlow.ContentStore    (Content ((:</>)))
 import qualified Control.FunFlow.ContentStore    as CS
 import qualified Control.FunFlow.External.Docker as Docker
-import           Control.Monad.Catch             (throwM)
 import           Data.Foldable                   (for_)
 import           Data.Store
 import           Data.Traversable                (for)

--- a/funflow/test/FunFlow/SQLiteCoordinator.hs
+++ b/funflow/test/FunFlow/SQLiteCoordinator.hs
@@ -6,7 +6,7 @@ module FunFlow.SQLiteCoordinator where
 
 import           Control.Arrow
 import           Control.Arrow.Free
-import           Control.Exception
+import           Control.Exception.Safe
 import           Control.FunFlow
 import qualified Control.FunFlow.ContentStore                as CS
 import           Control.FunFlow.External.Coordinator.SQLite

--- a/funflow/test/FunFlow/TestFlows.hs
+++ b/funflow/test/FunFlow/TestFlows.hs
@@ -7,7 +7,7 @@
 module FunFlow.TestFlows where
 
 import           Control.Arrow
-import           Control.Exception
+import           Control.Exception.Safe
 import           Control.FunFlow
 import           Control.FunFlow.ContentStore                (Content ((:</>)))
 import qualified Control.FunFlow.ContentStore                as CS


### PR DESCRIPTION
Depends on #56 

- Uses `withCreateProcess` to ensure that the external process is killed in the event of async or uncaught sync exceptions.
- Defines `bracket`-like `withConstructIfMissing` to ensure that pending items are removed in the event of async or uncaught sync exceptions.
- Logs async or uncaught sync exceptions in the executor.