### PR TITLE
Handle user interrupt

### DIFF
--- a/funflow/funflow.cabal
+++ b/funflow/funflow.cabal
@@ -110,11 +110,13 @@ Executable ffexecutord
   main-is: app/FFExecutorD.hs
   build-depends:       base >=4.6 && <5
                      , bytestring
+                     , clock
                      , funflow
                      , hedis
                      , path
                      , text
-                     , exceptions
+                     , unix
+                     , safe-exceptions
                      , optparse-applicative
 
 Test-suite test-funflow

--- a/funflow/src/Control/FunFlow/External/Coordinator.hs
+++ b/funflow/src/Control/FunFlow/External/Coordinator.hs
@@ -1,6 +1,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE StrictData                 #-}
 {-# LANGUAGE TemplateHaskell            #-}
 {-# LANGUAGE TypeFamilies               #-}
@@ -13,9 +14,11 @@ import           Control.FunFlow.External
 import           Control.Lens
 import           Control.Monad.IO.Class          (MonadIO, liftIO)
 
+import           Data.Monoid                     ((<>))
 import           Data.Store                      (Store)
 import           Data.Store.TH                   (makeStore)
 import           Data.Typeable                   (Typeable)
+import           Katip
 import           Network.HostName
 import           Path
 import           System.Clock                    (TimeSpec)
@@ -141,7 +144,7 @@ isInProgress h ch = do
 --   asynchronous exception, then the task will be placed back on the task
 --   queue and the exception propagated. Returns 'Nothing' if no task is
 --   available and @'Just' ()@ on task completion or regular failure.
-withPopTask :: (Coordinator c, MonadIO m, MonadMask m)
+withPopTask :: (Coordinator c, MonadIO m, MonadMask m, KatipContext m)
   => Hook c -> Executor
   -> (TaskDescription -> m (TimeSpec, Either Int ()))
   -> m (Maybe ())
@@ -150,8 +153,15 @@ withPopTask hook executor f =
     (popTask hook executor)
     (\case
       Nothing -> return ()
-      -- XXX: Log errors that happen here.
-      Just td -> update td Pending)
+      Just td ->
+        update td Pending
+        `withException`
+        \e -> $(logTM) ErrorS $
+          "Failed to place task "
+          <> showLS (td ^. tdOutput)
+          <> " back on queue: "
+          <> ls (displayException (e :: SomeException))
+        )
     (\case
       Nothing -> return Nothing
       Just td -> f td >>= \case

--- a/funflow/src/Control/FunFlow/External/Coordinator/SQLite.hs
+++ b/funflow/src/Control/FunFlow/External/Coordinator/SQLite.hs
@@ -292,7 +292,15 @@ instance Coordinator SQLite where
             , ":exit_code" SQL.:= exitCode
             , ":output" SQL.:= output
             ]
-          Pending -> throwIO $ IllegalStatusUpdate output ts
+          Pending -> SQL.executeNamed conn
+            "UPDATE tasks\
+            \ SET\
+            \  status = :pending\
+            \ WHERE\
+            \  output = :output"
+            [ ":pending" SQL.:= SqlPending
+            , ":output" SQL.:= output
+            ]
           Running _ -> throwIO $ IllegalStatusUpdate output ts
         _ -> throwIO $ NonRunningTask output
 

--- a/funflow/test/FunFlow/SQLiteCoordinator.hs
+++ b/funflow/test/FunFlow/SQLiteCoordinator.hs
@@ -121,6 +121,12 @@ tests = testGroup "SQLite Coordinator"
               threadDelay 500000
               -- Interrupt the executor while the external task is running.
               signalProcess Signals.sigINT executorHandle
+              -- Send a second interrupt shortly after. Users can be impatient.
+              -- GHC's default interrupt handler is one-time, after the first
+              -- interrupt was called a second will terminate the process
+              -- immediately, leaving no time for clean-up.
+              threadDelay 50000
+              signalProcess Signals.sigINT executorHandle
               threadDelay 2000000
               -- Check that the executor did not complete the task.
               progress <- readMVar mvar


### PR DESCRIPTION
- Uses a bracket-like function `withPopTask` in the executor, that will place the task back on the queue on unexpected failure. In particular, if the executor is cancelled by a user interrupt while working on a task, then the task will be placed back on the queue so that another executor can pick it up.
- Installs a custom interrupt handler in `ffexecutord` that can handle multiple user interrupts.
- Adds a test-case to test handling of two consecutive user interrupts with the sqlite coordinator.