### PR TITLE
Item and input hash dependencies in store metadata

### DIFF
--- a/funflow/src/Control/FunFlow/ContentStore.hs
+++ b/funflow/src/Control/FunFlow/ContentStore.hs
@@ -688,11 +688,9 @@ getMetadata :: (SQL.ToField k, SQL.FromField v, MonadIO m)
   => ContentStore -> ContentHash -> k -> m (Maybe v)
 getMetadata store hash k = liftIO . withStoreLock store $ do
   r <- SQL.queryNamed (storeDb store)
-    "SELECT FROM metadata\
+    "SELECT value FROM metadata\
     \ WHERE\
-    \  ( hash = :hash\
-    \  , key = :key\
-    \  )"
+    \  (hash = :hash AND key = :key)"
     [ ":hash" SQL.:= hash
     , ":key" SQL.:= k
     ]

--- a/funflow/src/Control/FunFlow/ContentStore.hs
+++ b/funflow/src/Control/FunFlow/ContentStore.hs
@@ -668,7 +668,9 @@ listAliases store = liftIO . withStoreLock store $
 -- | Set a metadata entry on a pending item.
 setMetadata :: (SQL.ToField k, SQL.ToField v, MonadIO m )
             => ContentStore -> ContentHash -> k -> v -> m ()
-setMetadata store hash k v = liftIO . withStoreLock store $
+setMetadata store hash k v = liftIO $
+  withStoreLock store $
+  withWritableStore store $
   internalQuery store hash >>= \case
     Pending _ -> SQL.executeNamed (storeDb store)
       "INSERT OR REPLACE INTO\

--- a/funflow/src/Control/FunFlow/ContentStore.hs
+++ b/funflow/src/Control/FunFlow/ContentStore.hs
@@ -960,6 +960,9 @@ initDb storeDir db = do
     \  , PRIMARY KEY(hash, key)\
     \  )"
 
+-- | Adds a link between input hash and the output hash.
+--
+-- Assumes that the store is locked and writable.
 addBackReference :: ContentStore -> ContentHash -> Item -> IO ()
 addBackReference store inHash (Item outHash) =
   SQL.executeNamed (storeDb store)

--- a/funflow/src/Control/FunFlow/ContentStore.hs
+++ b/funflow/src/Control/FunFlow/ContentStore.hs
@@ -694,7 +694,7 @@ setInputs store hash items = liftIO $
         ]
     _ -> throwIO $ NotPending hash
 
--- | Get the input items to a subtree if any where defined.
+-- | Get the input items to a subtree if any were defined.
 getInputs :: MonadIO m => ContentStore -> ContentHash -> m [Item]
 getInputs store hash = liftIO . withStoreLock store $
   map (Item . SQL.fromOnly) <$> SQL.queryNamed (storeDb store)

--- a/funflow/src/Control/FunFlow/External/Executor.hs
+++ b/funflow/src/Control/FunFlow/External/Executor.hs
@@ -13,7 +13,7 @@ import qualified Control.FunFlow.ContentStore         as CS
 import           Control.FunFlow.External
 import           Control.FunFlow.External.Coordinator
 import           Control.Lens
-import           Control.Monad                        (forever, when)
+import           Control.Monad                        (forever, mzero, when)
 import           Control.Monad.Trans                  (lift)
 import           Control.Monad.Trans.Maybe
 import qualified Data.ByteString                      as BS
@@ -80,6 +80,17 @@ execute store td = logError $ do
     params <- case mbParams of
       Nothing     -> fail "A parameter was not ready"
       Just params -> return params
+
+    let
+      inputItems :: [CS.Item]
+      inputItems = do
+        Param fields <- td ^. tdTask . etParams
+        ParamPath inputPath <- fields
+        case inputPath of
+          IPItem item -> pure item
+          IPExternalFile _ -> mzero
+          IPExternalDir _ -> mzero
+    CS.setInputs store (td ^. tdOutput) inputItems
 
     start <- lift $ getTime Monotonic
     let theProc = procSpec params

--- a/funflow/src/Control/FunFlow/External/Executor.hs
+++ b/funflow/src/Control/FunFlow/External/Executor.hs
@@ -89,6 +89,7 @@ execute store td = logError $ do
         ParamPath inputPath <- fields
         case inputPath of
           IPItem item -> pure item
+          -- XXX: Store these references as well.
           IPExternalFile _ -> mzero
           IPExternalDir _ -> mzero
     CS.setInputs store (td ^. tdOutput) inputItems

--- a/funflow/src/Control/FunFlow/External/Executor.hs
+++ b/funflow/src/Control/FunFlow/External/Executor.hs
@@ -16,6 +16,7 @@ import           Control.Lens
 import           Control.Monad                        (forever, mzero, when)
 import           Control.Monad.Trans                  (lift)
 import           Control.Monad.Trans.Maybe
+import qualified Data.Aeson                           as Json
 import qualified Data.ByteString                      as BS
 import           Data.Monoid                          ((<>))
 import qualified Data.Text                            as T
@@ -91,6 +92,9 @@ execute store td = logError $ do
           IPExternalFile _ -> mzero
           IPExternalDir _ -> mzero
     CS.setInputs store (td ^. tdOutput) inputItems
+    CS.setMetadata store (td ^. tdOutput)
+      ("external-task"::T.Text)
+      (Json.encode (td ^. tdTask))
 
     start <- lift $ getTime Monotonic
     let theProc = procSpec params


### PR DESCRIPTION
- fixes the store metadata mechanism
- exposes back-references from store items to input hashes
- stores the input items to an external task in the executor
- stores the task description in store metadata