### PR TITLE
Fix CircleCI cache invalidation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,13 @@ jobs:
       - image: fpco/stack-build
     steps:
       - checkout
+      - run:
+          name: Compute cache key
+          command: |
+            find . -name "*.cabal" -o -name "stack.yaml" -type f | sort | xargs cat > /tmp/stack-deps
       - restore_cache:
-          key: stack-deps-{{ checksum "stack.yaml" }}
+          keys:
+            - funflow-stack-deps-{{arch}}-{{checksum "/tmp/stack-deps"}}
       - run:
           name: Setup build toolchain
           command: stack setup
@@ -16,7 +21,7 @@ jobs:
       - save_cache:
           paths:
             - "~/.stack"
-          key: stack-deps-{{ checksum "stack.yaml" }}
+          key: funflow-stack-deps-{{arch}}-{{checksum "/tmp/stack-deps"}}
       - run:
           name: Building
           command: stack build --pedantic


### PR DESCRIPTION
We had the following in `.circleci/config.yaml`:

```yaml
  - restore_cache:
      key: stack-deps-{{ checksum "stack.yaml" }}
```

This is incorrect. If a .cabal file changes, this will change the set
of dependencies, yet the cache will not be invalidated. We should take
into account `stack.yaml`, all `*.cabal` files, and any `*.nix` files.