### PR TITLE
Only hash the external task

### DIFF
--- a/funflow/src/Control/Funflow/Base.hs
+++ b/funflow/src/Control/Funflow/Base.hs
@@ -88,8 +88,7 @@ instance Default ExternalProperties where
 data Flow' eff a b where
   Step :: Properties a b -> (a -> b) -> Flow' eff a b
   StepIO :: Properties a b -> (a -> IO b) -> Flow' eff a b
-  External :: ContentHashable IO a
-           => ExternalProperties
+  External :: ExternalProperties
            -> (a -> ExternalTask)
            -> Flow' eff a CS.Item
   -- XXX: Constrain allowed user actions.

--- a/funflow/src/Control/Funflow/Class.hs
+++ b/funflow/src/Control/Funflow/Class.hs
@@ -30,10 +30,9 @@ class (ArrowChoice arr, ArrowError ex arr) => ArrowFlow eff ex arr | arr -> eff 
   -- | Create a flow from an IO action.
   stepIO' :: Base.Properties a b -> (a -> IO b) -> arr a b
   -- | Create an external task in the flow.
-  external :: ContentHashable IO a => (a -> ExternalTask) -> arr a CS.Item
+  external :: (a -> ExternalTask) -> arr a CS.Item
   -- | Create an external task with additional properties
-  external' :: ContentHashable IO a
-            => Base.ExternalProperties -> (a -> ExternalTask) -> arr a CS.Item
+  external' :: Base.ExternalProperties -> (a -> ExternalTask) -> arr a CS.Item
   -- | Create a flow from a user-defined effect.
   wrap' :: Base.Properties a b -> eff a b -> arr a b
   -- | Create a flow which will write its incoming data to the store.

--- a/funflow/src/Control/Funflow/Exec/Simple.hs
+++ b/funflow/src/Control/Funflow/Exec/Simple.hs
@@ -115,7 +115,7 @@ runFlowEx _ cfg store runWrapped confIdent flow input = do
     runFlow' _ (StepIO props f) = withStoreCache (cache props)
       . liftAsyncA $ AsyncA f
     runFlow' po (External props toTask) = AsyncA $ \x -> do
-      chash <- liftIO $ contentHash (x, toTask x)
+      chash <- liftIO $ contentHash (toTask x)
       CS.lookup store chash >>= \case
         -- The item in question is already in the store. No need to submit a task.
         CS.Complete item -> return item


### PR DESCRIPTION
The external task is fully defined by the information contained in
`ExternalTask` it is not necessary to include the input that was used to
generate the `ExternalTask` in the hash.