### PR TITLE
Additional metadata in external tasks

### DIFF
--- a/funflow/src/Control/Funflow.hs
+++ b/funflow/src/Control/Funflow.hs
@@ -7,6 +7,8 @@ module Control.Funflow
   , Base.NoEffect
   , Base.Flow'(..)
   , Base.Cacher(..)
+  , Base.ExternalProperties(..)
+  , Base.MDWriter
   , Base.Properties(..)
   , Base.defaultCacherWithIdent
   , Cache.defaultCacher

--- a/funflow/src/Control/Funflow/Base.hs
+++ b/funflow/src/Control/Funflow/Base.hs
@@ -30,7 +30,7 @@ import           Path
 import           Prelude                         hiding (id, (.))
 
 -- | Metadata writer
-type MDWriter i o = Maybe (i -> o -> [(T.Text, T.Text)])
+type MDWriter i o = Maybe (i -> o -> [(T.Text, ByteString)])
 
 -- | A cacher is responsible for controlling how steps are cached.
 data Cacher i o =

--- a/funflow/src/Control/Funflow/Base.hs
+++ b/funflow/src/Control/Funflow/Base.hs
@@ -75,12 +75,12 @@ instance Default (Properties i o) where
     }
 
 -- | Additional properties associated with external tasks.
-newtype ExternalProperties = ExternalProperties
+newtype ExternalProperties a = ExternalProperties
   { -- | Write additional metadata to the content store.
-    ep_mdpolicy :: MDWriter ExternalTask ()
+    ep_mdpolicy :: MDWriter a ()
   }
 
-instance Default ExternalProperties where
+instance Default (ExternalProperties a) where
   def = ExternalProperties
     { ep_mdpolicy = Nothing
     }
@@ -88,7 +88,7 @@ instance Default ExternalProperties where
 data Flow' eff a b where
   Step :: Properties a b -> (a -> b) -> Flow' eff a b
   StepIO :: Properties a b -> (a -> IO b) -> Flow' eff a b
-  External :: ExternalProperties
+  External :: ExternalProperties a
            -> (a -> ExternalTask)
            -> Flow' eff a CS.Item
   -- XXX: Constrain allowed user actions.

--- a/funflow/src/Control/Funflow/Class.hs
+++ b/funflow/src/Control/Funflow/Class.hs
@@ -32,7 +32,7 @@ class (ArrowChoice arr, ArrowError ex arr) => ArrowFlow eff ex arr | arr -> eff 
   -- | Create an external task in the flow.
   external :: (a -> ExternalTask) -> arr a CS.Item
   -- | Create an external task with additional properties
-  external' :: Base.ExternalProperties -> (a -> ExternalTask) -> arr a CS.Item
+  external' :: Base.ExternalProperties a -> (a -> ExternalTask) -> arr a CS.Item
   -- | Create a flow from a user-defined effect.
   wrap' :: Base.Properties a b -> eff a b -> arr a b
   -- | Create a flow which will write its incoming data to the store.

--- a/funflow/src/Control/Funflow/ContentStore.hs
+++ b/funflow/src/Control/Funflow/ContentStore.hs
@@ -703,23 +703,21 @@ getInputs store hash = liftIO . withStoreLock store $
     \  hash = :hash"
     [ ":hash" SQL.:= hash ]
 
--- | Set a metadata entry on a pending item.
+-- | Set a metadata entry on an item.
 setMetadata :: (SQL.ToField k, SQL.ToField v, MonadIO m )
             => ContentStore -> ContentHash -> k -> v -> m ()
 setMetadata store hash k v = liftIO $
   withStoreLock store $
   withWritableStore store $
-  internalQuery store hash >>= \case
-    Pending _ -> SQL.executeNamed (storeDb store)
-      "INSERT OR REPLACE INTO\
-      \  metadata (hash, key, value)\
-      \ VALUES\
-      \  (:hash, :key, :value)"
-      [ ":hash" SQL.:= hash
-      , ":key" SQL.:= k
-      , ":value" SQL.:= v
-      ]
-    _ -> throwIO $ NotPending hash
+  SQL.executeNamed (storeDb store)
+    "INSERT OR REPLACE INTO\
+    \  metadata (hash, key, value)\
+    \ VALUES\
+    \  (:hash, :key, :value)"
+    [ ":hash" SQL.:= hash
+    , ":key" SQL.:= k
+    , ":value" SQL.:= v
+    ]
 
 -- | Retrieve a metadata entry on an item, or 'Nothing' if missing.
 getMetadata :: (SQL.ToField k, SQL.FromField v, MonadIO m)

--- a/funflow/src/Control/Funflow/Exec/Simple.hs
+++ b/funflow/src/Control/Funflow/Exec/Simple.hs
@@ -127,14 +127,14 @@ runFlowEx _ cfg store runWrapped confIdent flow input = do
           -- path and submit as normal.
           UnknownTask -> do
             CS.removeFailed store chash
-            writeMd chash (toTask x) () $ ep_mdpolicy props
+            writeMd chash x () $ ep_mdpolicy props
             submitAndWait chash (TaskDescription chash (toTask x))
           -- Task is already known to the coordinator. Most likely something is
           -- running this task. Just wait for it.
           KnownTask _ -> wait chash (TaskDescription chash (toTask x))
         -- Nothing in the store. Submit and run.
         CS.Missing _ -> do
-          writeMd chash (toTask x) () $ ep_mdpolicy props
+          writeMd chash x () $ ep_mdpolicy props
           submitAndWait chash (TaskDescription chash (toTask x))
       where
         submitAndWait chash td = do


### PR DESCRIPTION
- Pass original input to metadata writer
    The `ExternalTask` record alone does not contain much information that
would be useful to generate additional user-defined metadata.
- export `ExternalProperties` and `MDWriter`
- Store `ByteString` in external task metadata
    For more flexible metadata storage. E.g. encoded Haskell data-types. The SQLite database that stores the metadata is capable of storing arbitrary binary blobs.
- Allow to write metadata on non-pending items in `ContentStore`
    Previously, metadata could only be modified while a task was pending. Since the additional metadata storage happens in the flow executor, and not the external task executor, this cannot be guaranteed.