### PR TITLE
ContentHashable instance for `NonEmpty` and type fingerprint in list-like `ContentHashable` instances.

### DIFF
--- a/funflow/src/Control/Funflow/ContentHashable.hs
+++ b/funflow/src/Control/Funflow/ContentHashable.hs
@@ -67,12 +67,14 @@ import qualified Data.ByteString                  as BS
 import           Data.ByteString.Builder.Extra    (defaultChunkSize)
 import qualified Data.ByteString.Char8            as C8
 import qualified Data.ByteString.Lazy             as BSL
+import           Data.Foldable                    (foldlM)
 import           Data.Functor.Contravariant
 import qualified Data.Hashable
 import qualified Data.HashMap.Lazy                as HashMap
 import qualified Data.HashSet                     as HashSet
 import           Data.Int
 import           Data.List                        (sort)
+import           Data.List.NonEmpty               (NonEmpty)
 import           Data.Map                         (Map)
 import qualified Data.Map                         as Map
 import           Data.Ratio
@@ -359,6 +361,9 @@ instance (Typeable v, ContentHashable m v)
 
 instance ContentHashable m a => ContentHashable m [a] where
   contentHashUpdate = foldM contentHashUpdate
+
+instance ContentHashable m a => ContentHashable m (NonEmpty a) where
+  contentHashUpdate = foldlM contentHashUpdate
 
 instance ContentHashable m a => ContentHashable m (V.Vector a) where
   contentHashUpdate = V.foldM' contentHashUpdate

--- a/funflow/src/Control/Funflow/ContentHashable.hs
+++ b/funflow/src/Control/Funflow/ContentHashable.hs
@@ -359,14 +359,23 @@ instance (Typeable v, ContentHashable m v)
     -- XXX: The order of the list is unspecified.
     >=> flip contentHashUpdate (HashSet.toList s) $ ctx
 
-instance ContentHashable m a => ContentHashable m [a] where
-  contentHashUpdate = foldM contentHashUpdate
+instance (Typeable a, ContentHashable m a)
+  => ContentHashable m [a] where
+  contentHashUpdate ctx l =
+    flip contentHashUpdate_fingerprint l
+    >=> flip (foldM contentHashUpdate) l $ ctx
 
-instance ContentHashable m a => ContentHashable m (NonEmpty a) where
-  contentHashUpdate = foldlM contentHashUpdate
+instance (Typeable a, ContentHashable m a)
+  => ContentHashable m (NonEmpty a) where
+  contentHashUpdate ctx l =
+    flip contentHashUpdate_fingerprint l
+    >=> flip (foldlM contentHashUpdate) l $ ctx
 
-instance ContentHashable m a => ContentHashable m (V.Vector a) where
-  contentHashUpdate = V.foldM' contentHashUpdate
+instance (Typeable a, ContentHashable m a)
+  => ContentHashable m (V.Vector a) where
+  contentHashUpdate ctx v =
+    flip contentHashUpdate_fingerprint v
+    >=> flip (V.foldM' contentHashUpdate) v $ ctx
 
 instance Monad m => ContentHashable m ()
 instance (ContentHashable m a, ContentHashable m b) => ContentHashable m (a, b)


### PR DESCRIPTION
- Add `ContentHashable` instance for `NonEmpty` list
- Include fingerprint in list-like `ContentHashable` instances
    The type's fingerprint should be included in the `ContentHash` to avoid e.g. `[1,2,3] :: [Int]` and `1 :| [2, 3] 
 : NonEmpty Int` having the same `ContentHash`.
