### PR TITLE
extending docker config with params and stdout

### DIFF
--- a/funflow-examples/compile-and-run-c-files/Main.hs
+++ b/funflow-examples/compile-and-run-c-files/Main.hs
@@ -69,8 +69,9 @@ compileModule = proc csrc -> do
                        , ("data", IPItem $ CS.contentItem cInput)
                        ]
       , Docker.command = "/input/script/compile.sh"
-      , Docker.args = ["/input/data/out.c", "/output/out.o"]
+      , Docker.args = map stringParam ["/input/data/out.c", "/output/out.o"]
       , Docker.env = []
+      , Docker.stdout = NoOutputCapture
       }
 
 -- | This flow takes a list of files which are assumed to be 'C' modules.
@@ -95,11 +96,12 @@ compileExec = proc mods -> do
                        | (n, cMod) <- zip [1::Int ..] cModules
                        ]
       , Docker.command = "/input/script/compile.sh"
-      , Docker.args = "/output/out" :
+      , Docker.args = map textParam $ "/output/out" :
                       [ T.pack $ "/input/module"++show n++"/out.o"
                       | (n, _) <- zip [1::Int ..] cModules
                       ]
       , Docker.env = []
+      , Docker.stdout = NoOutputCapture
       }
 
 -- | This flow takes a file which is assumed to be an executable,
@@ -122,6 +124,7 @@ runExec = proc (exec, args) -> do
                        , ("exec", IPItem $ CS.contentItem exec)
                        ]
       , Docker.command = "/input/script/run.sh"
-      , Docker.args = map T.pack args
+      , Docker.args = map stringParam args
       , Docker.env = []
+      , Docker.stdout = NoOutputCapture
       }

--- a/funflow-examples/makefile-tool/src/Main.hs
+++ b/funflow-examples/makefile-tool/src/Main.hs
@@ -177,6 +177,7 @@ compileFile = proc (tf, srcDeps, tarDeps, cmd) -> do
         , Docker.command = "/input/script/script.sh"
         , Docker.args = []
         , Docker.env = []
+        , Docker.stdout = NoOutputCapture
         }
         where
           inputs = Map.fromList [scriptInput, depInput]

--- a/funflow-examples/makefile-tool/src/Types.hs
+++ b/funflow-examples/makefile-tool/src/Types.hs
@@ -3,7 +3,6 @@
 
 module Types where
 
-import Control.Funflow
 import qualified Data.Set as Set
 
 type Set = Set.Set
@@ -30,9 +29,6 @@ type Command = String
 
 -- Makefile error type
 newtype MFError = MFError String
-
--- Elegant flow syntax
-type (==>) = SimpleFlow
 
 
 

--- a/funflow/funflow.cabal
+++ b/funflow/funflow.cabal
@@ -1,5 +1,5 @@
 Name:                funflow
-Version:             1.1.0
+Version:             1.2.0
 Synopsis:            Workflows with arrows
 Description:
         An arrow with resumable computations and logging

--- a/funflow/src/Control/Funflow.hs
+++ b/funflow/src/Control/Funflow.hs
@@ -1,9 +1,12 @@
+{-# LANGUAGE TypeOperators #-}
+
 -- | Central Funflow module.
 --
 --   This module just re-exports various other modules for convenience.
 module Control.Funflow
   ( Base.Flow
   , Base.SimpleFlow
+  , type (Base.==>)
   , Base.NoEffect
   , Base.Flow'(..)
   , Base.Cacher(..)

--- a/funflow/src/Control/Funflow/Base.hs
+++ b/funflow/src/Control/Funflow/Base.hs
@@ -115,6 +115,7 @@ runNoEffect :: forall arr. NoEffect ~> arr
 runNoEffect = error "Impossible!"
 
 type SimpleFlow = Flow NoEffect SomeException
+type (==>) = SimpleFlow
 
 -- | Convert a flow to a diagram, for inspection/pretty printing
 toDiagram :: Flow eff ex a b -> Diagram ex a b

--- a/funflow/src/Control/Funflow/External/Docker.hs
+++ b/funflow/src/Control/Funflow/External/Docker.hs
@@ -35,8 +35,9 @@ data Config = Config
   , optImageID :: Maybe T.Text
   , input      :: Bind
   , command    :: FilePath
-  , args       :: [T.Text]
+  , args       :: [Param]
   , env        :: [(T.Text, T.Text)]
+  , stdout     :: OutputCapture
   } deriving Generic
 
 instance ContentHashable IO Config
@@ -51,9 +52,9 @@ toExternal cfg = ExternalTask
       ] ++ mounts ++
       [ imageArg
       , stringParam (command cfg)
-      ] ++ map textParam (args cfg)
+      ] ++ (args cfg)
   , _etEnv = map (fmap textParam) (env cfg)
-  , _etWriteToStdOut = NoOutputCapture
+  , _etWriteToStdOut = stdout cfg
   }
   where
     mounts = outputMount : inputMounts


### PR DESCRIPTION
I added support for params and stdout capturing for docker. 
Also, I added the alias ==> for SimpleFlow.

Should we change the version number?