### PR TITLE
Support inheriting the environment for external tasks.

### DIFF
--- a/funflow-cwl/src/Control/Funflow/CWL/Convert/Tool.hs
+++ b/funflow-cwl/src/Control/Funflow/CWL/Convert/Tool.hs
@@ -90,7 +90,7 @@ externalFn cmd' mkParams stdCapture env inHList =
     ExternalTask
       { _etCommand = T.pack cmd'
       , _etParams = mkParams inHList
-      , _etEnv = map (fmap textParam) (env inHList)
+      , _etEnv = EnvExplicit $ map (fmap textParam) (env inHList)
       , _etWriteToStdOut = outCapture
       }
 
@@ -108,7 +108,7 @@ dockerFn cmd' img mkParams stdCapture env inHList = D.toExternal $
     , D.optImageID = Nothing
     , D.command = stringParam cmd'
     , D.args = mkParams inHList
-    , D.env = map (onSnd textParam) $ env inHList
+    , D.env = EnvExplicit $ map (onSnd textParam) $ env inHList
     , D.stdout = determineStdOut stdCapture
     }
 

--- a/funflow-examples/compile-and-run-c-files/Main.hs
+++ b/funflow-examples/compile-and-run-c-files/Main.hs
@@ -64,7 +64,7 @@ compileModule = proc csrc -> do
       , Docker.optImageID = Just "7.3.0"
       , Docker.command = contentParam scriptInput
       , Docker.args = [contentParam cInput, textParam "/output/out.o"]
-      , Docker.env = []
+      , Docker.env = EnvExplicit []
       , Docker.stdout = NoOutputCapture
       }
 
@@ -86,7 +86,7 @@ compileExec = proc mods -> do
       , Docker.optImageID = Just "7.3.0"
       , Docker.command = contentParam scriptInput
       , Docker.args = textParam "/output/out" : map contentParam cModules
-      , Docker.env = []
+      , Docker.env = EnvExplicit []
       , Docker.stdout = NoOutputCapture
       }
 
@@ -109,6 +109,6 @@ runExec = proc (exec, args) -> do
       , Docker.optImageID = Just "7.3.0"
       , Docker.command = contentParam script
       , Docker.args = contentParam exec : map stringParam args
-      , Docker.env = []
+      , Docker.env = EnvExplicit []
       , Docker.stdout = NoOutputCapture
       }

--- a/funflow-examples/makefile-tool/src/Main.hs
+++ b/funflow-examples/makefile-tool/src/Main.hs
@@ -173,7 +173,7 @@ compileFile = proc (tf, srcDeps, tarDeps, cmd) -> do
         , Docker.optImageID = Just "7.3.0"
         , Docker.command = contentParam compileScript
         , Docker.args = [contentParam depDir]
-        , Docker.env = []
+        , Docker.env = EnvExplicit []
         , Docker.stdout = NoOutputCapture
         }
 

--- a/funflow/TestFunflow.hs
+++ b/funflow/TestFunflow.hs
@@ -56,7 +56,7 @@ externalTest = let
       { _etCommand = "/run/current-system/sw/bin/echo"
       , _etParams = [textParam t]
       , _etWriteToStdOut = StdOutCapture
-      , _etEnv = []
+      , _etEnv = EnvExplicit []
       }
     flow = exFlow >>> readString_
   in withSystemTempDir "test_output_external_" $ \storeDir -> do
@@ -74,7 +74,7 @@ storeTest = let
       { _etCommand = "/run/current-system/sw/bin/cat"
       , _etParams = [contentParam a, contentParam b]
       , _etWriteToStdOut = StdOutCapture
-      , _etEnv = []
+      , _etEnv = EnvExplicit []
       }
     flow = proc (s1, s2) -> do
       f1 <- writeString_ -< s1

--- a/funflow/src/Control/Funflow/External.hs
+++ b/funflow/src/Control/Funflow/External.hs
@@ -179,13 +179,29 @@ instance FromJSON OutputCapture
 instance ToJSON OutputCapture
 instance Store OutputCapture
 
+-- | Control the environment set for the external process. This can either
+--   inherit from the surrounding environment, or explicitly set things.
+data Env
+    -- | Inherit all environment variables from the surrounding shell. Note that
+    -- the values of these variables will not be taken into account in the
+    -- content hash, and so changes to them will not trigger a rerun of the
+    -- step.
+  = EnvInherit
+  | EnvExplicit [(T.Text, Param)]
+  deriving (Generic, Show)
+
+instance ContentHashable IO Env
+instance FromJSON Env
+instance ToJSON Env
+instance Store Env
+
 -- | A monomorphic description of an external task. This is basically just
 --   a command which can be run.
 data ExternalTask = ExternalTask {
     _etCommand       :: T.Text
   , _etParams        :: [Param]
     -- ^ Environment variables to set for the scope of the execution.
-  , _etEnv           :: [(T.Text, Param)]
+  , _etEnv           :: Env
   , _etWriteToStdOut :: OutputCapture
 } deriving (Generic, Show)
 

--- a/funflow/test/Funflow/SQLiteCoordinator.hs
+++ b/funflow/test/Funflow/SQLiteCoordinator.hs
@@ -71,7 +71,7 @@ echo = external $ \msg -> ExternalTask
   { _etCommand = "echo"
   , _etWriteToStdOut = StdOutCapture
   , _etParams = ["-n", fromString msg]
-  , _etEnv = []
+  , _etEnv = EnvExplicit []
   }
 
 sleepEcho :: SimpleFlow (Double, String) CS.Item
@@ -83,7 +83,7 @@ sleepEcho = external $ \(time, msg) -> ExternalTask
       , "sleep " <> fromString (show time) <> ";"
         <> "echo -n " <> fromString msg
       ]
-  , _etEnv = []
+  , _etEnv = EnvExplicit []
   }
 
 flow :: SimpleFlow () String

--- a/funflow/test/Funflow/TestFlows.hs
+++ b/funflow/test/Funflow/TestFlows.hs
@@ -89,7 +89,7 @@ flowMissingExecutable = proc () -> do
     { _etCommand = "non-existent-executable-39fd1e85a0a05113938e0"
     , _etParams = []
     , _etWriteToStdOut = StdOutCapture
-    , _etEnv = []
+    , _etEnv = EnvExplicit []
     }))
     `catch` arr (Left @SomeException . snd)
     -< ()
@@ -104,7 +104,7 @@ externalEnvVar = proc () -> do
     { _etCommand = "bash"
     , _etParams = [textParam "-c", textParam "echo -n $FOO"]
     , _etWriteToStdOut = StdOutCapture
-    , _etEnv = [("FOO", textParam "testing")]
+    , _etEnv = EnvExplicit [("FOO", textParam "testing")]
     }) -< ()
   returnA -< case r of
     "testing" -> Right ()


### PR DESCRIPTION
This used to be the standard behaviour, but was changed, breaking some
downstream tools.