### PR TITLE
ArrowError defines `try' instead of `catch'

### DIFF
--- a/funflow-examples/makefile-tool/src/Main.hs
+++ b/funflow-examples/makefile-tool/src/Main.hs
@@ -8,7 +8,7 @@ module Main where
 
 -- Funflow Imports
 import           Control.Arrow
-import           Control.Arrow.Free
+import           Control.Arrow.Free              hiding (try)
 import           Control.Exception               (Exception (..),
                                                   SomeException (..))
 import           Control.Exception.Safe          (try)

--- a/funflow/src/Control/Arrow/Async.hs
+++ b/funflow/src/Control/Arrow/Async.hs
@@ -40,8 +40,7 @@ instance MonadBaseControl IO m => ArrowChoice (AsyncA m) where
 
 instance (Exception ex, MonadBaseControl IO m, MonadCatch m)
   => ArrowError ex (AsyncA m) where
-    AsyncA arr1 `catch` AsyncA arr2 = AsyncA $ \x ->
-      arr1 x `Control.Exception.Safe.catch` curry arr2 x
+  try (AsyncA a) = AsyncA $ Control.Exception.Safe.try . a
 
 -- | Lift an AsyncA through a monad transformer of the underlying monad.
 liftAsyncA :: (MonadTrans t, Monad m)

--- a/funflow/src/Control/Funflow/Class.hs
+++ b/funflow/src/Control/Funflow/Class.hs
@@ -24,7 +24,7 @@ import           Control.Funflow.External
 import           Data.Default                    (def)
 import           Path
 
-class (ArrowChoice arr, ArrowError ex arr) => ArrowFlow eff ex arr | arr -> eff ex where
+class (Arrow arr, ArrowError ex arr) => ArrowFlow eff ex arr | arr -> eff ex where
   -- | Create a flow from a pure function.
   step' :: Base.Properties a b -> (a -> b) -> arr a b
   -- | Create a flow from an IO action.

--- a/funflow/src/Control/Funflow/Diagram.hs
+++ b/funflow/src/Control/Funflow/Diagram.hs
@@ -33,7 +33,7 @@ data Diagram ex a b where
   Seq :: Diagram ex a b -> Diagram ex b c -> Diagram ex a c
   Par :: Diagram ex a b -> Diagram ex c d -> Diagram ex (a,c) (b,d)
   Fanin :: Diagram ex a c -> Diagram ex b c -> Diagram ex (Either a b) c
-  Catch   :: Diagram ex a b -> Diagram ex (a,ex) b -> Diagram ex a b
+  Try :: Diagram ex a b -> Diagram ex a (Either ex b)
 
 instance Category (Diagram ex) where
   id = Node emptyNodeProperties Proxy Proxy
@@ -51,7 +51,7 @@ instance ArrowChoice (Diagram ex) where
   f ||| g = Fanin f g
 
 instance ArrowError ex (Diagram ex) where
-  f `catch` g = Catch f g
+  try = Try
 
 -- | Construct a labelled node
 node :: forall arr a b ex. Arrow arr => arr a b -> [T.Text] -> (Diagram ex) a b

--- a/funflow/src/Control/Funflow/Pretty.hs
+++ b/funflow/src/Control/Funflow/Pretty.hs
@@ -18,7 +18,7 @@ ppFlow = ppDiagram . toDiagram where
   ppDiagram (Seq f g) = parens $ ppDiagram f <+> text ">>>" <+> ppDiagram g
   ppDiagram (Par f g) = parens $ ppDiagram f <+>  text "***" <+> ppDiagram g
   ppDiagram (Fanin f g) = parens $ ppDiagram f <+>  text "|||" <+> ppDiagram g
-  ppDiagram (Catch f g) = parens $ ppDiagram f <+>  text "catch" <+> ppDiagram g
+  ppDiagram (Try f) = parens $ text "try" <+> ppDiagram f
 
 showFlow :: Flow eff ex a b -> String
 showFlow = render . ppFlow

--- a/funflow/src/Control/Funflow/Steps.hs
+++ b/funflow/src/Control/Funflow/Steps.hs
@@ -140,7 +140,8 @@ copyFileToStore = putInStoreAt $ \p (FileContent inFP) -> copyFile inFP p
 --
 -- | @copyDirToStore (dIn, Just dOut)@ copies the contents of @dIn@ into the store
 -- under relative path @dOut@ within the subtree
-copyDirToStore :: ArrowFlow eff ex arr => arr (DirectoryContent, Maybe (Path Rel Dir)) (CS.Content Dir)
+copyDirToStore :: (ArrowChoice arr, ArrowFlow eff ex arr)
+               => arr (DirectoryContent, Maybe (Path Rel Dir)) (CS.Content Dir)
 copyDirToStore = proc (inDir, mbOutDir) ->
   case mbOutDir of
     Nothing -> do

--- a/funflow/src/Control/Funflow/Steps.hs
+++ b/funflow/src/Control/Funflow/Steps.hs
@@ -107,7 +107,7 @@ melancholicLazarus = stepIO $ \s -> do
 
 -- | `retry n s f` reruns `f` on failure at most n times with a delay of `s`
 --   seconds between retries
-retry :: forall arr eff ex a b. (Exception ex, Store a, ArrowFlow eff ex arr)
+retry :: forall arr eff ex a b. (Exception ex, Store a, ArrowFlow eff ex arr, ArrowChoice arr)
       => Int -> Int -> arr a b -> arr a b
 retry 0 _ f = f
 retry n secs f = catch f $ proc (x, _ :: ex) -> do


### PR DESCRIPTION
For the same reasons I explained in https://github.com/tweag/funflow/pull/122 , it can be in some cases difficult to implement `catch`, because you end up with an arrow branch that _might or not_ be evaluated, and in cases where we want in the end a more static view of the complete program that can be an issue.

`try` doesn't have this problem. Of course, we will want to do some pattern matching and branching in the next step, based on the `Either` we get, but the important difference is that this branching _doesn't have to be done at the ArrowFlow level_, it can be done by the underlying effect layer (in `porcupine`, that mean we make it impossible for error-handling code to define new resources, because that's clearly not its job). Plus it simplifies a bit the implementation of ArrowError, since `try` is a bit shorter to implement usually.

Note that `catch` of course still exists (it just requires `ArrowChoice`), so client code isn't affected.