### PR TITLE
Added AppArrow combinator and its instances

### DIFF
--- a/funflow/funflow.cabal
+++ b/funflow/funflow.cabal
@@ -24,7 +24,8 @@ Library
    default-language:  Haskell2010
 
    Exposed-modules:
-                     Control.Arrow.Async
+                     Control.Arrow.AppArrow
+                   , Control.Arrow.Async
                    , Control.Arrow.Free
                    , Control.Funflow
                    , Control.Funflow.Cache.TH

--- a/funflow/src/Control/Arrow/AppArrow.hs
+++ b/funflow/src/Control/Arrow/AppArrow.hs
@@ -27,6 +27,13 @@ instance (Applicative app, ArrowChoice arr) => ArrowChoice (AppArrow app arr) wh
   right (AppArrow a) = AppArrow $ right <$> a
   AppArrow a1 +++ AppArrow a2 = AppArrow $ (+++) <$> a1 <*> a2
   AppArrow a1 ||| AppArrow a2 = AppArrow $ (|||) <$> a1 <*> a2
-  
+
+instance (Applicative f, Arrow arr) => Functor (AppArrow f arr t) where
+  fmap f = (>>> arr f)
+
+instance (Applicative app, Arrow arr) => Applicative (AppArrow app arr t) where
+  pure = arr . const
+  a <*> b = a &&& b >>> arr (uncurry ($))
+
 appArrow :: (Applicative app) => arr a b -> AppArrow app arr a b
 appArrow = AppArrow . pure

--- a/funflow/src/Control/Arrow/AppArrow.hs
+++ b/funflow/src/Control/Arrow/AppArrow.hs
@@ -1,0 +1,32 @@
+-- | This modules defines the composition of an applicative functor and an
+-- arrow, which is always an arrow.
+
+module Control.Arrow.AppArrow
+  ( AppArrow(..)
+  , appArrow
+  ) where
+
+import Control.Category
+import Control.Arrow
+import Prelude          hiding (id, (.))
+
+newtype AppArrow app arr a b = AppArrow { unAppArrow :: app (arr a b) }
+
+instance (Applicative app, Category cat) => Category (AppArrow app cat) where
+  id = appArrow id
+  AppArrow a1 . AppArrow a2 = AppArrow $ (.) <$> a1 <*> a2
+
+instance (Applicative app, Arrow arr) => Arrow (AppArrow app arr) where
+  arr = appArrow . arr
+  first (AppArrow a) = AppArrow $ first <$> a
+  second (AppArrow a) = AppArrow $ second <$> a
+  AppArrow a1 *** AppArrow a2 = AppArrow $ (***) <$> a1 <*> a2
+
+instance (Applicative app, ArrowChoice arr) => ArrowChoice (AppArrow app arr) where
+  left (AppArrow a) = AppArrow $ left <$> a
+  right (AppArrow a) = AppArrow $ right <$> a
+  AppArrow a1 +++ AppArrow a2 = AppArrow $ (+++) <$> a1 <*> a2
+  AppArrow a1 ||| AppArrow a2 = AppArrow $ (|||) <$> a1 <*> a2
+  
+appArrow :: (Applicative app) => arr a b -> AppArrow app arr a b
+appArrow = AppArrow . pure

--- a/funflow/src/Control/Arrow/Free.hs
+++ b/funflow/src/Control/Arrow/Free.hs
@@ -172,12 +172,12 @@ instance (ArrowError ex arr) => ArrowError ex (AppArrow (Reader r) arr) where
     try $ runReader act r
 
 instance (ArrowError ex arr, Monoid w) => ArrowError ex (AppArrow (Writer w) arr) where
-  try (AppArrow act) = AppArrow $ writer (try arr, w)
-    where (arr, w) = runWriter act
+  try (AppArrow act) = AppArrow $ writer (try a, w)
+    where (a, w) = runWriter act
 
 instance (ArrowError ex arr, Monoid w) => ArrowError ex (AppArrow (SW.Writer w) arr) where
-  try (AppArrow act) = AppArrow $ SW.writer (try arr, w)
-    where (arr, w) = SW.runWriter act
+  try (AppArrow act) = AppArrow $ SW.writer (try a, w)
+    where (a, w) = SW.runWriter act
 
 catch :: (ArrowError ex a, ArrowChoice a) => a e c -> a (e, ex) c -> a e c
 catch a onExc = proc e -> do

--- a/funflow/src/Control/Funflow/Class.hs
+++ b/funflow/src/Control/Funflow/Class.hs
@@ -22,9 +22,6 @@ import qualified Control.Funflow.Base            as Base
 import           Control.Funflow.ContentHashable
 import qualified Control.Funflow.ContentStore    as CS
 import           Control.Funflow.External
-import           Control.Monad.Trans.Reader
-import           Control.Monad.Trans.Writer
-import qualified Control.Monad.Trans.Writer.Strict as SW
 import           Data.Default                    (def)
 import           Path
 

--- a/funflow/src/Control/Funflow/Class.hs
+++ b/funflow/src/Control/Funflow/Class.hs
@@ -16,11 +16,15 @@
 module Control.Funflow.Class where
 
 import           Control.Arrow
+import           Control.Arrow.AppArrow
 import           Control.Arrow.Free
 import qualified Control.Funflow.Base            as Base
 import           Control.Funflow.ContentHashable
 import qualified Control.Funflow.ContentStore    as CS
 import           Control.Funflow.External
+import           Control.Monad.Trans.Reader
+import           Control.Monad.Trans.Writer
+import qualified Control.Monad.Trans.Writer.Strict as SW
 import           Data.Default                    (def)
 import           Path
 
@@ -64,3 +68,16 @@ stepIO = stepIO' def
 
 wrap :: ArrowFlow eff ex arr => eff a b -> arr a b
 wrap = wrap' def
+
+instance ( Applicative app
+         , ArrowError ex (AppArrow app (arr eff ex))
+         , ArrowFlow eff ex (arr eff ex) )
+      => ArrowFlow eff ex (AppArrow app (arr eff ex)) where
+  step' props f = appArrow $ step' props f
+  stepIO' props f = appArrow $ stepIO' props f
+  external f = appArrow $ external f
+  external' props f = appArrow $ external' props f
+  wrap' props eff = appArrow $ wrap' props eff
+  putInStore f = appArrow $ putInStore f
+  getFromStore f = appArrow $ getFromStore f
+  internalManipulateStore f = appArrow $ internalManipulateStore f


### PR DESCRIPTION
The composition of an Applicative and an Arrow is always an Arrow.
It is the same for ArrowFlow. This permits to add global effects to the flow (for instance some general Writer or Reader context) that can be inspected without having to inspect the flow's effects (which is  difficult to do when using `ErrorChoice`). This way, such a composition can inherit instances of Arrow/ArrowChoice/ArrowError/ArrowFlow for free.