### PR TITLE
Fix: Build failures in GHC 8.6 (including nix build)

### DIFF
--- a/funflow-checkpoints/test/Tests.hs
+++ b/funflow-checkpoints/test/Tests.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE Arrows                     #-}
+{-# LANGUAGE BangPatterns               #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}

--- a/funflow/funflow.cabal
+++ b/funflow/funflow.cabal
@@ -1,5 +1,5 @@
 Name:                funflow
-Version:             1.4.0
+Version:             1.4.1
 Synopsis:            Workflows with arrows
 Description:
         An arrow with resumable computations and logging

--- a/funflow/src/Control/Funflow/Exec/Simple.hs
+++ b/funflow/src/Control/Funflow/Exec/Simple.hs
@@ -149,7 +149,9 @@ runFlowEx _ cfg store runWrapped confIdent flow input = do
           submitTask po td
           wait chash td
         wait chash td = do
-          _ <- awaitTask po chash
+          awaitTask po chash >>= \case
+            KnownTask _ -> pure ()
+            _ -> error "[Control.Funflow.Exec.Simple.runFlowEx] Expected KnownTask."
           CS.waitUntilComplete store chash >>= \case
             Just item -> return item
             Nothing -> do

--- a/funflow/src/Control/Funflow/Exec/Simple.hs
+++ b/funflow/src/Control/Funflow/Exec/Simple.hs
@@ -149,7 +149,7 @@ runFlowEx _ cfg store runWrapped confIdent flow input = do
           submitTask po td
           wait chash td
         wait chash td = do
-          KnownTask _ <- awaitTask po chash
+          _ <- awaitTask po chash
           CS.waitUntilComplete store chash >>= \case
             Just item -> return item
             Nothing -> do

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.21
+resolver: lts-13.4
 
 packages:
 - funflow
@@ -9,7 +9,6 @@ packages:
 - funflow-cwl
 
 extra-deps:
-- katip-0.6.0.0
 - aws-0.20
 
 nix:


### PR DESCRIPTION
This was due to a partial pattern match. Since the use of this pattern match is
meant to represent an unfailable case, we simply use a wildcard bind here
instead. If this fails in some case, it's not the end of the world, since the
task shouldn't be in the store and an error will be thrown there.

Addresses issue #134 