### PR TITLE
CI: building dependencies at -j1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           command: stack setup
       - run:
           name: Building dependencies
-          command: stack test --only-snapshot --prefetch
+          command: stack -j1 test --only-snapshot --prefetch
       - save_cache:
           paths:
             - "~/.stack"

--- a/funflow-cwl/app/FFCwlRunner.hs
+++ b/funflow-cwl/app/FFCwlRunner.hs
@@ -10,7 +10,7 @@ import Data.Monoid ((<>))
 import qualified Options.Applicative as Opt
 import qualified Database.Redis as R
 import qualified Data.ByteString as B
-import Network.Socket.Internal ( PortNumber )
+import Network.Socket (HostName, PortNumber )
 
 
 import           Data.HList
@@ -107,7 +107,7 @@ argsParser = Args
         <> Opt.help "Password for the Redis instance, if needed." ))
 
     useRedis ::
-      R.HostName -> PortNumber -> Maybe B.ByteString -> UseCoord
+      HostName -> PortNumber -> Maybe B.ByteString -> UseCoord
     useRedis host port pw = UseRedis $ R.defaultConnectInfo
       { R.connectHost = host
       , R.connectPort = R.PortNumber port
@@ -119,5 +119,3 @@ argsParser = Args
       <$> Opt.strArgument
         (  Opt.metavar "SQLFILE"
         <> Opt.help "Path to SQLite database file." )
-
-

--- a/funflow/app/FFExecutorD.hs
+++ b/funflow/app/FFExecutorD.hs
@@ -19,6 +19,7 @@ import           Control.Funflow.External.Executor
 import           Control.Monad                               (void)
 import           Data.Monoid                                 ((<>))
 import qualified Database.Redis                              as R
+import           Network.Socket                              (PortNumber)
 import qualified Options.Applicative                         as Opt
 import           Path
 import           System.Clock
@@ -64,7 +65,7 @@ argsParser = Opt.subparser
         <> Opt.help "Password for the Redis instance, if needed." ))
     useRedis store host port pw = Args store $ UseRedis R.defaultConnectInfo
       { R.connectHost = host
-      , R.connectPort = R.PortNumber port
+      , R.connectPort = R.PortNumber (port :: PortNumber)
       , R.connectAuth = pw
       }
     sqliteParser = useSQLite

--- a/funflow/funflow.cabal
+++ b/funflow/funflow.cabal
@@ -109,7 +109,8 @@ Executable ffexecutord
                      , bytestring
                      , clock
                      , funflow
-                     , hedis
+                     , hedis >= 0.12.5
+                     , network
                      , path
                      , text
                      , unix
@@ -125,7 +126,7 @@ Test-suite test-funflow
   build-depends:       base >=4.6 && <5
                      , funflow
                      , filepath
-                     , hedis
+                     , hedis >= 0.12.5
                      , path
                      , path-io
                      , text

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.4
+resolver: lts-13.19
 
 packages:
 - funflow
@@ -10,6 +10,7 @@ packages:
 
 extra-deps:
 - aws-0.20
+- hedis-0.12.5@sha256:5e3f47b935a48e57c44197f715a26d88a33c46c045a8c19d75b0d7ebc4ae3cbe
 
 nix:
   packages:


### PR DESCRIPTION
stack defaults to -j > 1 which may cause OOM errors.