### PR TITLE
[lts-14.6] Update stack resolver to lts-14.6

### DIFF
--- a/funflow-cwl/src/Control/Funflow/CWL/PreProcess.hs
+++ b/funflow-cwl/src/Control/Funflow/CWL/PreProcess.hs
@@ -75,8 +75,11 @@ getMaybeTy _ = Nothing
 
 -- | Given the object for a cwlwf or tool,
 -- determine the input schema.
-getInSchema :: Object -> ErrM (M.HashMap String CWLType)
-getInSchema = parseMonad parseInSchema
+getInSchema :: Object -> IOErrM (M.HashMap String CWLType)
+getInSchema o =
+  case parseEither parseInSchema o of
+    Left errmsg -> throwM $ ErrMsg $ errmsg
+    Right map -> return map
 
 parseInSchema :: Object -> Parser (M.HashMap String CWLType)
 parseInSchema obj = do

--- a/funflow-cwl/src/Control/Funflow/CWL/Run.hs
+++ b/funflow-cwl/src/Control/Funflow/CWL/Run.hs
@@ -116,7 +116,6 @@ tryRun (Args cwlpath jobpath store useCoord) = do
 -- * The steps to execute a cwl workflow or tool.
 --------------------------------------------------------------------------------
 
-
 -- | Try to parse two JSON values into a 'CWLFile' and 'Job'
 -- respectively.
 tryParse :: Value -> Value -> IOErrM (CWLFile, Job)
@@ -124,11 +123,11 @@ tryParse cwlfileVal jobVal = do
   cwlfile :: CWLFile <- parseValue cwlfileVal
   job :: Job <- parseValue jobVal
   return (cwlfile, job)
-
   where
     parseValue :: FromJSON a => Value -> IOErrM a
-    parseValue = parseMonad parseJSON
-
+    parseValue v = case parseEither parseJSON v of
+                    Left errmsg -> throwM $ ErrMsg $ errmsg
+                    Right a -> return a
 
 
 -- | An existential type for a Flow that takes

--- a/funflow/funflow.cabal
+++ b/funflow/funflow.cabal
@@ -68,7 +68,7 @@ Library
                , hedis
                , hostname
                , integer-gmp
-               , katip                   >= 0.5.0.1
+               , katip                   >= 0.8.0.0
                , lens
                , lifted-async
                , memory

--- a/funflow/src/Control/Funflow/Exec/Simple.hs
+++ b/funflow/src/Control/Funflow/Exec/Simple.hs
@@ -21,7 +21,6 @@ module Control.Funflow.Exec.Simple
   , withSimpleLocalRunner
   ) where
 
-import           Control.Arrow                               (returnA)
 import           Control.Arrow.Async
 import           Control.Arrow.Free                          (type (~>), eval)
 import           Control.Concurrent.Async                    (withAsync)
@@ -220,7 +219,7 @@ runSimpleFlow :: forall m c a b.
         -> a
         -> m (Either SomeException b)
 runSimpleFlow c ccfg store flow input = do
-  handleScribe <- liftIO $ mkHandleScribe ColorIfTerminal stderr InfoS V2
+  handleScribe <- liftIO $ mkHandleScribe ColorIfTerminal stderr (permitItem InfoS) V2
   let mkLogEnv = liftIO $
         registerScribe "stderr" handleScribe defaultScribeSettings =<< initLogEnv "funflow" "production"
   bracket mkLogEnv (liftIO . closeScribes) $ \le -> do

--- a/funflow/src/Control/Funflow/External/Executor.hs
+++ b/funflow/src/Control/Funflow/External/Executor.hs
@@ -162,7 +162,7 @@ executeLoop :: forall c. Coordinator c
             -> IO ()
 executeLoop coord cfg store =
   executeLoopWithScribe coord cfg store =<<
-    mkHandleScribe ColorIfTerminal stdout InfoS V2
+    mkHandleScribe ColorIfTerminal stdout (permitItem InfoS) V2
 
 -- | Same as 'executeLoop', but allows specifying a custom 'Scribe' for logging
 executeLoopWithScribe :: forall c. Coordinator c

--- a/nix/.stack.nix/funflow-aws.nix
+++ b/nix/.stack.nix/funflow-aws.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
@@ -17,20 +56,20 @@
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.funflow)
-          (hsPkgs.aeson)
-          (hsPkgs.aws)
-          (hsPkgs.conduit)
-          (hsPkgs.conduit-extra)
-          (hsPkgs.constraints)
-          (hsPkgs.http-conduit)
-          (hsPkgs.lens)
-          (hsPkgs.path)
-          (hsPkgs.path-io)
-          (hsPkgs.reflection)
-          (hsPkgs.resourcet)
-          (hsPkgs.text)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."funflow" or (buildDepError "funflow"))
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."aws" or (buildDepError "aws"))
+          (hsPkgs."conduit" or (buildDepError "conduit"))
+          (hsPkgs."conduit-extra" or (buildDepError "conduit-extra"))
+          (hsPkgs."constraints" or (buildDepError "constraints"))
+          (hsPkgs."http-conduit" or (buildDepError "http-conduit"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."path" or (buildDepError "path"))
+          (hsPkgs."path-io" or (buildDepError "path-io"))
+          (hsPkgs."reflection" or (buildDepError "reflection"))
+          (hsPkgs."resourcet" or (buildDepError "resourcet"))
+          (hsPkgs."text" or (buildDepError "text"))
           ];
         };
       };

--- a/nix/.stack.nix/funflow-checkpoints.nix
+++ b/nix/.stack.nix/funflow-checkpoints.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
@@ -15,17 +54,22 @@
       buildType = "Simple";
       };
     components = {
-      "library" = { depends = [ (hsPkgs.base) (hsPkgs.funflow) ]; };
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."funflow" or (buildDepError "funflow"))
+          ];
+        };
       tests = {
         "unit-tests" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.funflow)
-            (hsPkgs.funflow-checkpoints)
-            (hsPkgs.path-io)
-            (hsPkgs.safe-exceptions)
-            (hsPkgs.tasty)
-            (hsPkgs.tasty-hunit)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."funflow" or (buildDepError "funflow"))
+            (hsPkgs."funflow-checkpoints" or (buildDepError "funflow-checkpoints"))
+            (hsPkgs."path-io" or (buildDepError "path-io"))
+            (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))
             ];
           };
         };

--- a/nix/.stack.nix/funflow-cwl.nix
+++ b/nix/.stack.nix/funflow-cwl.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
@@ -17,62 +56,62 @@
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.async)
-          (hsPkgs.bytestring)
-          (hsPkgs.containers)
-          (hsPkgs.directory)
-          (hsPkgs.exceptions)
-          (hsPkgs.filepath)
-          (hsPkgs.funflow)
-          (hsPkgs.hashable)
-          (hsPkgs.ilist)
-          (hsPkgs.katip)
-          (hsPkgs.parsec)
-          (hsPkgs.path)
-          (hsPkgs.path-io)
-          (hsPkgs.process)
-          (hsPkgs.scientific)
-          (hsPkgs.text)
-          (hsPkgs.transformers)
-          (hsPkgs.unordered-containers)
-          (hsPkgs.vector)
-          (hsPkgs.yaml)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."async" or (buildDepError "async"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."directory" or (buildDepError "directory"))
+          (hsPkgs."exceptions" or (buildDepError "exceptions"))
+          (hsPkgs."filepath" or (buildDepError "filepath"))
+          (hsPkgs."funflow" or (buildDepError "funflow"))
+          (hsPkgs."hashable" or (buildDepError "hashable"))
+          (hsPkgs."ilist" or (buildDepError "ilist"))
+          (hsPkgs."katip" or (buildDepError "katip"))
+          (hsPkgs."parsec" or (buildDepError "parsec"))
+          (hsPkgs."path" or (buildDepError "path"))
+          (hsPkgs."path-io" or (buildDepError "path-io"))
+          (hsPkgs."process" or (buildDepError "process"))
+          (hsPkgs."scientific" or (buildDepError "scientific"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+          (hsPkgs."vector" or (buildDepError "vector"))
+          (hsPkgs."yaml" or (buildDepError "yaml"))
           ];
         };
       exes = {
         "ffcwlrunner" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.bytestring)
-            (hsPkgs.directory)
-            (hsPkgs.funflow)
-            (hsPkgs.funflow-cwl)
-            (hsPkgs.hedis)
-            (hsPkgs.network)
-            (hsPkgs.optparse-applicative)
-            (hsPkgs.path)
-            (hsPkgs.path-io)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."directory" or (buildDepError "directory"))
+            (hsPkgs."funflow" or (buildDepError "funflow"))
+            (hsPkgs."funflow-cwl" or (buildDepError "funflow-cwl"))
+            (hsPkgs."hedis" or (buildDepError "hedis"))
+            (hsPkgs."network" or (buildDepError "network"))
+            (hsPkgs."optparse-applicative" or (buildDepError "optparse-applicative"))
+            (hsPkgs."path" or (buildDepError "path"))
+            (hsPkgs."path-io" or (buildDepError "path-io"))
             ];
           };
         };
       tests = {
         "tests" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.containers)
-            (hsPkgs.deepseq)
-            (hsPkgs.directory)
-            (hsPkgs.filepath)
-            (hsPkgs.funflow)
-            (hsPkgs.funflow-cwl)
-            (hsPkgs.path)
-            (hsPkgs.path-io)
-            (hsPkgs.safe-exceptions)
-            (hsPkgs.tasty)
-            (hsPkgs.tasty-hunit)
-            (hsPkgs.transformers)
-            (hsPkgs.yaml)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."deepseq" or (buildDepError "deepseq"))
+            (hsPkgs."directory" or (buildDepError "directory"))
+            (hsPkgs."filepath" or (buildDepError "filepath"))
+            (hsPkgs."funflow" or (buildDepError "funflow"))
+            (hsPkgs."funflow-cwl" or (buildDepError "funflow-cwl"))
+            (hsPkgs."path" or (buildDepError "path"))
+            (hsPkgs."path-io" or (buildDepError "path-io"))
+            (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))
+            (hsPkgs."transformers" or (buildDepError "transformers"))
+            (hsPkgs."yaml" or (buildDepError "yaml"))
             ];
           };
         };

--- a/nix/.stack.nix/funflow-examples.nix
+++ b/nix/.stack.nix/funflow-examples.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
@@ -18,47 +57,47 @@
       exes = {
         "external-c-computation" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.containers)
-            (hsPkgs.funflow)
-            (hsPkgs.path)
-            (hsPkgs.path-io)
-            (hsPkgs.text)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."funflow" or (buildDepError "funflow"))
+            (hsPkgs."path" or (buildDepError "path"))
+            (hsPkgs."path-io" or (buildDepError "path-io"))
+            (hsPkgs."text" or (buildDepError "text"))
             ];
           };
         "makefile-tool" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.containers)
-            (hsPkgs.funflow)
-            (hsPkgs.path)
-            (hsPkgs.path-io)
-            (hsPkgs.text)
-            (hsPkgs.katip)
-            (hsPkgs.safe-exceptions)
-            (hsPkgs.data-default)
-            (hsPkgs.directory)
-            (hsPkgs.parsec)
-            (hsPkgs.unix)
-            (hsPkgs.bytestring)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."funflow" or (buildDepError "funflow"))
+            (hsPkgs."path" or (buildDepError "path"))
+            (hsPkgs."path-io" or (buildDepError "path-io"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."katip" or (buildDepError "katip"))
+            (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
+            (hsPkgs."data-default" or (buildDepError "data-default"))
+            (hsPkgs."directory" or (buildDepError "directory"))
+            (hsPkgs."parsec" or (buildDepError "parsec"))
+            (hsPkgs."unix" or (buildDepError "unix"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
             ];
           };
         "omdb" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.aeson)
-            (hsPkgs.async)
-            (hsPkgs.containers)
-            (hsPkgs.data-default)
-            (hsPkgs.funflow)
-            (hsPkgs.lens)
-            (hsPkgs.lens-aeson)
-            (hsPkgs.optparse-generic)
-            (hsPkgs.path)
-            (hsPkgs.path-io)
-            (hsPkgs.safe-exceptions)
-            (hsPkgs.text)
-            (hsPkgs.wreq)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."async" or (buildDepError "async"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."data-default" or (buildDepError "data-default"))
+            (hsPkgs."funflow" or (buildDepError "funflow"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."lens-aeson" or (buildDepError "lens-aeson"))
+            (hsPkgs."optparse-generic" or (buildDepError "optparse-generic"))
+            (hsPkgs."path" or (buildDepError "path"))
+            (hsPkgs."path-io" or (buildDepError "path-io"))
+            (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."wreq" or (buildDepError "wreq"))
             ];
           };
         };

--- a/nix/.stack.nix/funflow-jobs.nix
+++ b/nix/.stack.nix/funflow-jobs.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
@@ -17,17 +56,17 @@
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.bytestring)
-          (hsPkgs.exceptions)
-          (hsPkgs.funflow)
-          (hsPkgs.hedis)
-          (hsPkgs.lens)
-          (hsPkgs.monad-control)
-          (hsPkgs.mtl)
-          (hsPkgs.store)
-          (hsPkgs.text)
-          (hsPkgs.transformers-base)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."exceptions" or (buildDepError "exceptions"))
+          (hsPkgs."funflow" or (buildDepError "funflow"))
+          (hsPkgs."hedis" or (buildDepError "hedis"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."monad-control" or (buildDepError "monad-control"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."store" or (buildDepError "store"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."transformers-base" or (buildDepError "transformers-base"))
           ];
         };
       };

--- a/nix/.stack.nix/funflow.nix
+++ b/nix/.stack.nix/funflow.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
@@ -17,103 +56,103 @@
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.Glob)
-          (hsPkgs.aeson)
-          (hsPkgs.async)
-          (hsPkgs.bytestring)
-          (hsPkgs.clock)
-          (hsPkgs.constraints)
-          (hsPkgs.containers)
-          (hsPkgs.contravariant)
-          (hsPkgs.cryptonite)
-          (hsPkgs.data-default)
-          (hsPkgs.directory)
-          (hsPkgs.exceptions)
-          (hsPkgs.filepath)
-          (hsPkgs.ghc-prim)
-          (hsPkgs.hashable)
-          (hsPkgs.hedis)
-          (hsPkgs.hostname)
-          (hsPkgs.integer-gmp)
-          (hsPkgs.katip)
-          (hsPkgs.lens)
-          (hsPkgs.lifted-async)
-          (hsPkgs.memory)
-          (hsPkgs.monad-control)
-          (hsPkgs.mtl)
-          (hsPkgs.path)
-          (hsPkgs.path-io)
-          (hsPkgs.pretty)
-          (hsPkgs.process)
-          (hsPkgs.random)
-          (hsPkgs.safe-exceptions)
-          (hsPkgs.scientific)
-          (hsPkgs.sqlite-simple)
-          (hsPkgs.stm)
-          (hsPkgs.store)
-          (hsPkgs.template-haskell)
-          (hsPkgs.text)
-          (hsPkgs.time)
-          (hsPkgs.transformers)
-          (hsPkgs.unix)
-          (hsPkgs.unordered-containers)
-          (hsPkgs.vector)
-          (hsPkgs.yaml)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."Glob" or (buildDepError "Glob"))
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."async" or (buildDepError "async"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."clock" or (buildDepError "clock"))
+          (hsPkgs."constraints" or (buildDepError "constraints"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."contravariant" or (buildDepError "contravariant"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."data-default" or (buildDepError "data-default"))
+          (hsPkgs."directory" or (buildDepError "directory"))
+          (hsPkgs."exceptions" or (buildDepError "exceptions"))
+          (hsPkgs."filepath" or (buildDepError "filepath"))
+          (hsPkgs."ghc-prim" or (buildDepError "ghc-prim"))
+          (hsPkgs."hashable" or (buildDepError "hashable"))
+          (hsPkgs."hedis" or (buildDepError "hedis"))
+          (hsPkgs."hostname" or (buildDepError "hostname"))
+          (hsPkgs."integer-gmp" or (buildDepError "integer-gmp"))
+          (hsPkgs."katip" or (buildDepError "katip"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."lifted-async" or (buildDepError "lifted-async"))
+          (hsPkgs."memory" or (buildDepError "memory"))
+          (hsPkgs."monad-control" or (buildDepError "monad-control"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."path" or (buildDepError "path"))
+          (hsPkgs."path-io" or (buildDepError "path-io"))
+          (hsPkgs."pretty" or (buildDepError "pretty"))
+          (hsPkgs."process" or (buildDepError "process"))
+          (hsPkgs."random" or (buildDepError "random"))
+          (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
+          (hsPkgs."scientific" or (buildDepError "scientific"))
+          (hsPkgs."sqlite-simple" or (buildDepError "sqlite-simple"))
+          (hsPkgs."stm" or (buildDepError "stm"))
+          (hsPkgs."store" or (buildDepError "store"))
+          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."time" or (buildDepError "time"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."unix" or (buildDepError "unix"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+          (hsPkgs."vector" or (buildDepError "vector"))
+          (hsPkgs."yaml" or (buildDepError "yaml"))
           ] ++ (if system.isLinux
-          then [ (hsPkgs.hinotify) ]
-          else (pkgs.lib).optional (system.isOsx || system.isFreebsd) (hsPkgs.kqueue));
+          then [ (hsPkgs."hinotify" or (buildDepError "hinotify")) ]
+          else (pkgs.lib).optional (system.isOsx || system.isFreebsd) (hsPkgs."kqueue" or (buildDepError "kqueue")));
         };
       exes = {
         "ffexecutord" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.bytestring)
-            (hsPkgs.clock)
-            (hsPkgs.funflow)
-            (hsPkgs.hedis)
-            (hsPkgs.network)
-            (hsPkgs.path)
-            (hsPkgs.text)
-            (hsPkgs.unix)
-            (hsPkgs.safe-exceptions)
-            (hsPkgs.optparse-applicative)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."clock" or (buildDepError "clock"))
+            (hsPkgs."funflow" or (buildDepError "funflow"))
+            (hsPkgs."hedis" or (buildDepError "hedis"))
+            (hsPkgs."network" or (buildDepError "network"))
+            (hsPkgs."path" or (buildDepError "path"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."unix" or (buildDepError "unix"))
+            (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
+            (hsPkgs."optparse-applicative" or (buildDepError "optparse-applicative"))
             ];
           };
         };
       tests = {
         "test-funflow" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.data-default)
-            (hsPkgs.funflow)
-            (hsPkgs.filepath)
-            (hsPkgs.hedis)
-            (hsPkgs.path)
-            (hsPkgs.path-io)
-            (hsPkgs.text)
-            (hsPkgs.safe-exceptions)
-            (hsPkgs.unix)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."data-default" or (buildDepError "data-default"))
+            (hsPkgs."funflow" or (buildDepError "funflow"))
+            (hsPkgs."filepath" or (buildDepError "filepath"))
+            (hsPkgs."hedis" or (buildDepError "hedis"))
+            (hsPkgs."path" or (buildDepError "path"))
+            (hsPkgs."path-io" or (buildDepError "path-io"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
+            (hsPkgs."unix" or (buildDepError "unix"))
             ];
           };
         "unit-tests" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.async)
-            (hsPkgs.containers)
-            (hsPkgs.data-default)
-            (hsPkgs.directory)
-            (hsPkgs.filepath)
-            (hsPkgs.funflow)
-            (hsPkgs.path)
-            (hsPkgs.path-io)
-            (hsPkgs.process)
-            (hsPkgs.random)
-            (hsPkgs.safe-exceptions)
-            (hsPkgs.tasty)
-            (hsPkgs.tasty-hunit)
-            (hsPkgs.temporary)
-            (hsPkgs.unix)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."async" or (buildDepError "async"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."data-default" or (buildDepError "data-default"))
+            (hsPkgs."directory" or (buildDepError "directory"))
+            (hsPkgs."filepath" or (buildDepError "filepath"))
+            (hsPkgs."funflow" or (buildDepError "funflow"))
+            (hsPkgs."path" or (buildDepError "path"))
+            (hsPkgs."path-io" or (buildDepError "path-io"))
+            (hsPkgs."process" or (buildDepError "process"))
+            (hsPkgs."random" or (buildDepError "random"))
+            (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))
+            (hsPkgs."temporary" or (buildDepError "temporary"))
+            (hsPkgs."unix" or (buildDepError "unix"))
             ];
           };
         };

--- a/nix/.stack.nix/pkgs.nix
+++ b/nix/.stack.nix/pkgs.nix
@@ -1,7 +1,7 @@
 {
   extras = hackage:
     {
-      packages = {
+      packages = ({
         "aws" = (((hackage.aws)."0.20").revisions).default;
         "hedis" = (((hackage.hedis)."0.12.5").revisions)."5e3f47b935a48e57c44197f715a26d88a33c46c045a8c19d75b0d7ebc4ae3cbe";
         } // {
@@ -11,7 +11,7 @@
         funflow-jobs = ./funflow-jobs.nix;
         funflow-examples = ./funflow-examples.nix;
         funflow-cwl = ./funflow-cwl.nix;
-        };
+        }) // {};
       };
-  resolver = "lts-13.25";
+  resolver = "lts-14.6";
   }

--- a/nix/haskell.nix-src.json
+++ b/nix/haskell.nix-src.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/haskell.nix",
-  "rev": "54086725c5b371042018faf62898783b080ee873",
-  "date": "2019-06-16T11:29:00+02:00",
-  "sha256": "1nw3nm5byamj0hwp810ljl27rbbm7kw9kf0is4qkrkga86mjfks8",
+  "rev": "03cf2369e03e40f32c9ac2a9e13385234ab4b12f",
+  "date": "2019-09-17T01:06:00+00:00",
+  "sha256": "0fj2w028rjq9hikvzzs3cyll9npx05h58rqrh6anfahd695wfqll",
   "fetchSubmodules": false
 }

--- a/nix/nixpkgs-src.json
+++ b/nix/nixpkgs-src.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/nixos/nixpkgs",
-  "rev": "aa2f3eb8b102ffed4258a7e7fbc0a7d17b7ba319",
-  "date": "2019-06-16T09:43:43+02:00",
-  "sha256": "1lz6jnw1nxwq05i2zf6i5sg29xn5yhmi5rdfyyz8wyl6p12v65y7",
+  "rev": "83686eb1fbab85a8631e28ae9c2517deb2380a80",
+  "date": "2019-09-17T07:44:40-04:00",
+  "sha256": "0svq78mwra0l0afq28wspm4dg4q3f6342wifm56xxgcxp1z6204i",
   "fetchSubmodules": false
 }

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.25
+resolver: lts-14.6
 
 packages:
 - funflow


### PR DESCRIPTION
- Update Katip mkHandleScribe calls for lts-14.6
- Remove unused imports (from -Wunused-imports)
- Remove Data.Yaml deprecation warning

  Use parseEither instead of parseMonad and wrap a case split around it so that
  type signatures do not change.

This is orthogonal to branch remote-caching