### PR TITLE
Use nix-store and nix-instantiate instead of nix-build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
             USER=dummy cachix use tweag
       - run:
           name: Building
-          command: nix-build nix/ci.nix -A required-packages | cachix push tweag
+          command: nix-store --query --requisites --include-outputs $(nix-instantiate nix/ci.nix -A required-packages) | cachix push tweag
       - run:
           name: Running tests
           command: nix-build nix/ci.nix -A required-tests | cachix push tweag

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
             USER=dummy cachix use tweag
       - run:
           name: Building
-          command: nix-store --query --requisites --include-outputs $(nix-instantiate nix/ci.nix -A required-packages) | cachix push tweag
+          command: nix-store --query $(nix-instantiate nix/ci.nix -A required-packages) | cachix push tweag
       - run:
           name: Running tests
           command: nix-build nix/ci.nix -A required-tests | cachix push tweag


### PR DESCRIPTION
Fixes #146.

See https://github.com/tweag/funflow/issues/146#issuecomment-538329316 for background. I've basically replaced the `nix-build` invocation with a more explicit `nix-store --query` combined with `nix-instantiate` the way it is done in `capacity` (but without changing the semantics: we still only push the direct outputs and not their closure - whether the full closure should be pushed is an orthogonal issue).

I am not sure how exactly this fixes the underlying issue of #146; the only explanation I can think of is that there is a bug in `nix-build` that messes up stdout forwarding from the implicit `nix-store --realise` call somehow.