### PR TITLE
Enable CI runs for pull requests

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -1,6 +1,8 @@
 name: funflow CI (Linux, Nix)
 
-on: [push, pull_request]
+on:
+  - push
+  - pull_request
 
 jobs:
   build:


### PR DESCRIPTION
Somewhere along the way of migrating the contents of the funflow2 repo we seem to have lost the PR event in our GitHub Actions workflow. This PR re-enables CI runs for pull requests.
