### PR TITLE
Fix space leak when hashing structures with Generic instance

### DIFF
--- a/cas/hashable/app/Main.hs
+++ b/cas/hashable/app/Main.hs
@@ -1,0 +1,38 @@
+{-# OPTIONS -Wall #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
+import GHC.Generics (Generic)
+import Data.CAS.ContentHashable
+import Control.Monad (when)
+
+-- | This type exists to test the generic implementation of 'contentHash'.
+-- It includes newtypes, product types, sum types, primitive types.
+data Foo = Foo
+  { ident :: Fiz Int,
+    name :: String,
+    dog :: Maybe Int,
+    bli :: Float,
+    blo :: Either Bar Int,
+    blz :: Either Bar Bar
+  }
+  deriving (Generic, ContentHashable m)
+
+data Bar = Bar Float Int Float
+  deriving (Generic, ContentHashable m)
+
+newtype Fiz a = Fiz a
+  deriving (Generic, ContentHashable m)
+
+main :: IO ()
+main = do
+  -- This should not take much memory. The toplevel 'Foo' structure is shared
+  -- between the 100K instances, so with overhead, this should not take much
+  -- more than a few MiB.
+  -- Computing the hash should also be constant space (i.e. a hash is a small
+  -- structure and it should walk lazyly in the main "huge" structure).
+  rawHash <- contentHash $ replicate 100000 (Foo (Fiz 10) "hello" (Just 5) 123.12 (Left (Bar 1 1 2)) (Right (Bar 4 5 6)))
+
+  -- This hash should not change, unless the hashing algorithm change or the order of the walk in the structure changes.
+  let 
+      expected = "ContentHash \"7f953cc9aaf79bac4d02e70dca91da1ee630b4a7894aeca9ed61942cc3a20d8a\""
+  when (show rawHash /= expected) $ error $ "Raw hash is different than expected: " <> show rawHash

--- a/cas/hashable/cas-hashable.cabal
+++ b/cas/hashable/cas-hashable.cabal
@@ -55,10 +55,31 @@ library
 
 test-suite perf
   main-is: Main.hs
-  ghc-options: -rtsopts -O2
+  other-modules:
+      Paths_cas_hashable
+  ghc-options: -Wall -rtsopts -O2
   hs-source-dirs:
       app
   build-depends:
-    cas-hashable,
-    base
+      aeson
+    , base >=4.6 && <5
+    , bytestring
+    , cas-hashable
+    , clock
+    , containers
+    , cryptonite
+    , ghc-prim
+    , hashable
+    , integer-gmp
+    , memory
+    , path
+    , path-io
+    , safe-exceptions
+    , scientific
+    , text
+    , time
+    , unix
+    , unordered-containers
+    , vector
+  default-language: Haskell2010
   type: exitcode-stdio-1.0

--- a/cas/hashable/cas-hashable.cabal
+++ b/cas/hashable/cas-hashable.cabal
@@ -52,3 +52,13 @@ library
     , unordered-containers
     , vector
   default-language: Haskell2010
+
+test-suite perf
+  main-is: Main.hs
+  ghc-options: -rtsopts -O2
+  hs-source-dirs:
+      app
+  build-depends:
+    cas-hashable,
+    base
+  type: exitcode-stdio-1.0

--- a/cas/hashable/changelog.md
+++ b/cas/hashable/changelog.md
@@ -1,0 +1,1 @@
+- Fix space leak when hashing structure where instances were derived using `Generic`. Now hashing happen in constant space. @guibou.

--- a/cas/hashable/package.yaml
+++ b/cas/hashable/package.yaml
@@ -36,3 +36,13 @@ extra-source-files: changelog.md
 
 library:
   source-dirs: src
+
+tests:
+  perf:
+    main: Main.hs
+    source-dirs: app
+    ghc-options:
+      - -rtsopts -O2
+    dependencies:
+      - base >=4.6 && <5
+      - cas-hashable

--- a/cas/hashable/src/Data/CAS/ContentHashable.hs
+++ b/cas/hashable/src/Data/CAS/ContentHashable.hs
@@ -456,12 +456,12 @@ instance ContentHashable m c => GContentHashable m (K1 i c) where
   gContentHashUpdate ctx x = contentHashUpdate ctx (unK1 x)
 
 instance (Constructor c, GContentHashable m f) => GContentHashable m (C1 c f) where
-  gContentHashUpdate ctx0 x = gContentHashUpdate nameCtx (unM1 x)
+  gContentHashUpdate ctx0 x = nameCtx `seq` gContentHashUpdate nameCtx (unM1 x)
     where
       nameCtx = hashUpdate ctx0 $ C8.pack (conName x)
 
 instance (Datatype d, GContentHashable m f) => GContentHashable m (D1 d f) where
-  gContentHashUpdate ctx0 x = gContentHashUpdate packageCtx (unM1 x)
+  gContentHashUpdate ctx0 x = packageCtx `seq` gContentHashUpdate packageCtx (unM1 x)
     where
       datatypeCtx = hashUpdate ctx0 $ C8.pack (datatypeName x)
       moduleCtx = hashUpdate datatypeCtx $ C8.pack (datatypeName x)
@@ -471,7 +471,7 @@ instance GContentHashable m f => GContentHashable m (S1 s f) where
   gContentHashUpdate ctx x = gContentHashUpdate ctx (unM1 x)
 
 instance (GContentHashable m a, GContentHashable m b) => GContentHashable m (a :*: b) where
-  gContentHashUpdate ctx (x :*: y) = gContentHashUpdate ctx x >>= flip gContentHashUpdate y
+  gContentHashUpdate ctx (x :*: y) = gContentHashUpdate ctx x >>= \ctx' -> ctx' `seq` gContentHashUpdate ctx' y
 
 instance (GContentHashable m a, GContentHashable m b) => GContentHashable m (a :+: b) where
   gContentHashUpdate ctx (L1 x) = gContentHashUpdate ctx x


### PR DESCRIPTION
See intermediate commit for details.

I introduce a small test case, run it with `cabal run perf -- +RTS -s`. On master branch, this test case takes more than 3 GiB of peak memory.

Once MR applied, it only takes 2 MiB.

The problem was in the way the `gContentHashUpdate` function was working. It uses the pattern:

```haskell
gContentHashUpdate ctx foo = gContentHashUpdate ctx' bar
   where ctx' = hashUpdate ctx biz
```

In this context, `ctx`` was not evaluated and was generating a THUNK only resolved at the end of the complete recursion on the datastructure for which the hash is computed. On a big datastructure, that's a lot of THUNK, plus the additional context captured by the THUNK (here `ctx` and `biz`).

Problem solve with `seq` applied each time this pattern was appearing (e.g. a recursive call to `gContentHashUpdate` with modified context).

Close #201 .