### PR TITLE
Fix GitHub Pages deployment

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -46,7 +46,7 @@ jobs:
       # Deploy documentation to a Github page
       - name: Deploy docs
         # Push to GitHub Pages only on master
-        if: github.ref == 'refs/heads/master'
+        # if: github.ref == 'refs/heads/master'
         uses: peaceiris/actions-gh-pages@v3.7.3
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Deploy docs
         # Push to GitHub Pages only on master
         if: github.ref == 'refs/heads/master'
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v3.7.3
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           publish_dir: ./funflow-pages/result/funflow

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Deploy docs
         # Push to GitHub Pages only on master
         # if: github.ref == 'refs/heads/master'
-        uses: peaceiris/actions-gh-pages@v3.7.3
+        uses: JamesIves/github-pages-deploy-action@v4.2.5
         with:
-          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-          publish_dir: ./funflow-pages/result/funflow
+          branch: gh-pages
+          folder: ./funflow-pages/result/funflow

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -46,7 +46,7 @@ jobs:
       # Deploy documentation to a Github page
       - name: Deploy docs
         # Push to GitHub Pages only on master
-        # if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         uses: JamesIves/github-pages-deploy-action@v4.2.5
         with:
           branch: gh-pages

--- a/funflow-pages/scripts/build.sh
+++ b/funflow-pages/scripts/build.sh
@@ -21,8 +21,9 @@ stack haddock
 cp -r "$(stack path --local-doc-root)" "$out"/api/
 chmod -R +rwx "$out"/api/
 # Add extra symlink for header "Contents" links
-mkdir -p "$out"/api/share/doc/
-ln -s -f "$out"/api/doc/index.html "$out"/api/index.html
+# mkdir -p "$out"/api/share/doc/
+mv "${out}"/api/doc/* "${out}"/api
+# ln -s -f "$out"/api/doc/index.html "$out"/api/index.html
 
 # Make tutorials
 mkdir -p /tmp/funflow/store

--- a/funflow-pages/scripts/build.sh
+++ b/funflow-pages/scripts/build.sh
@@ -22,7 +22,7 @@ cp -r "$(stack path --local-doc-root)" "$out"/api/
 chmod -R +rwx "$out"/api/
 # Add extra symlink for header "Contents" links
 mkdir -p "$out"/api/share/doc/
-ln -s "$out"/api/index.html "$out"/api/share/doc/doc-index.html
+ln -s -f "$out"/api/doc/index.html "$out"/api/index.html
 
 # Make tutorials
 mkdir -p /tmp/funflow/store

--- a/funflow-pages/scripts/build.sh
+++ b/funflow-pages/scripts/build.sh
@@ -20,10 +20,7 @@ mkdir -p "$out"/api
 stack haddock
 cp -r "$(stack path --local-doc-root)" "$out"/api/
 chmod -R +rwx "$out"/api/
-# Add extra symlink for header "Contents" links
-# mkdir -p "$out"/api/share/doc/
 mv "${out}"/api/doc/* "${out}"/api
-# ln -s -f "$out"/api/doc/index.html "$out"/api/index.html
 
 # Make tutorials
 mkdir -p /tmp/funflow/store


### PR DESCRIPTION
Somewhere along the way the action for deploying to GitHub pages started silently failing, resulting in the project's static website not being accessible. This PR updates the action used for deploying to one which is more transparent and fixes the underlying issue that was preventing the website from being deployed.

Fixes #203 and #204