### PR TITLE
Support for Aeson 2 and text 2

### DIFF
--- a/cas/hashable/cas-hashable.cabal
+++ b/cas/hashable/cas-hashable.cabal
@@ -46,7 +46,7 @@ library
     , path-io
     , safe-exceptions
     , scientific
-    , text
+    , text >= 2.0
     , time
     , unix
     , unordered-containers

--- a/cas/hashable/cas-hashable.cabal
+++ b/cas/hashable/cas-hashable.cabal
@@ -32,7 +32,7 @@ library
       src
   ghc-options: -Wall
   build-depends:
-      aeson
+      aeson >= 2.0.0.0
     , base >=4.9 && <5
     , bytestring
     , clock

--- a/cas/hashable/src/Data/CAS/ContentHashable.hs
+++ b/cas/hashable/src/Data/CAS/ContentHashable.hs
@@ -251,8 +251,8 @@ contentHashUpdate_byteArray# ba (I# off) (I# len) ctx = hashUpdate ctx $
 
 -- | Update hash context based on the contents of a strict 'Data.Text.Text'.
 contentHashUpdate_text :: Context SHA256 -> T.Text -> Context SHA256
-contentHashUpdate_text ctx (T.Text arr off_ len_) =
-  contentHashUpdate_byteArray# (TA.aBA arr) off len ctx
+contentHashUpdate_text ctx (T.Text (TA.ByteArray arr) off_ len_) =
+  contentHashUpdate_byteArray# arr off len ctx
   where
     off = off_ `shiftL` 1 -- convert from 'Word16' to 'Word8'
     len = len_ `shiftL` 1 -- convert from 'Word16' to 'Word8'

--- a/cas/hashable/src/Data/CAS/ContentHashable.hs
+++ b/cas/hashable/src/Data/CAS/ContentHashable.hs
@@ -59,6 +59,8 @@ import Crypto.Hash
   )
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Types as Aeson
+import qualified Data.Aeson.KeyMap as Aeson
+import qualified Data.Aeson.Key as Aeson
 import Data.Bits (shiftL)
 import Data.ByteArray
   ( Bytes,
@@ -442,6 +444,12 @@ instance ContentHashable m a => ContentHashable m (Maybe a)
 instance (ContentHashable m a, ContentHashable m b) => ContentHashable m (Either a b)
 
 instance Monad m => ContentHashable m Aeson.Value
+
+instance Monad m => ContentHashable m (Aeson.KeyMap Aeson.Value) where
+  contentHashUpdate ctx m = contentHashUpdate ctx (Aeson.toList m)
+
+instance Monad m => ContentHashable m Aeson.Key where
+  contentHashUpdate ctx k = contentHashUpdate ctx (Aeson.toText k)
 
 class Monad m => GContentHashable m f where
   gContentHashUpdate :: Context SHA256 -> f a -> m (Context SHA256)


### PR DESCRIPTION
These commit provides support for both `aeson` and `text` 2 which changed their internal API.

It does not provide backward compatibility, so I bumped the cabal bounds.

Tell me if you would prefer a version with backward compatibility.

Note: I think it will invalidate all the hash computed for both `aeson` and `text` values, due to the change in the internal representation.