### PR TITLE
Replace uses of unix-compat with unix to fix builds on GHC 9.4+

### DIFF
--- a/docker-client/docker-client.cabal
+++ b/docker-client/docker-client.cabal
@@ -53,7 +53,7 @@ library
     , string-conversions
     , tar-conduit
     , text >=2.0.1 && <2.1
-    , unix-compat
+    , unix
   default-language: Haskell2010
 
 test-suite primary
@@ -87,5 +87,5 @@ test-suite primary
     , tasty-hunit
     , temporary
     , text
-    , unix-compat
+    , unix
   default-language: Haskell2010

--- a/docker-client/package.yaml
+++ b/docker-client/package.yaml
@@ -30,7 +30,7 @@ dependencies:
   - string-conversions
   - tar-conduit
   - text                          >= 2.0.1 && < 2.1
-  - unix-compat
+  - unix
 
 
 library:
@@ -50,4 +50,4 @@ tests:
       - tasty-hunit
       - temporary
       - text
-      - unix-compat
+      - unix

--- a/docker-client/test/Test.hs
+++ b/docker-client/test/Test.hs
@@ -13,7 +13,7 @@ import Network.HTTP.Client (Manager)
 import System.Directory (doesDirectoryExist, doesFileExist, getCurrentDirectory, listDirectory)
 import System.IO.Temp (withSystemTempDirectory, withSystemTempFile)
 import System.Info (os)
-import System.PosixCompat.User (getEffectiveGroupID, getEffectiveUserID)
+import System.Posix.User (getEffectiveGroupID, getEffectiveUserID)
 import Test.Tasty
 import Test.Tasty.HUnit
 

--- a/funflow/funflow.cabal
+++ b/funflow/funflow.cabal
@@ -61,7 +61,7 @@ library
     , store
     , temporary
     , text >=2.0
-    , unix-compat
+    , unix
     , unliftio
     , unordered-containers
     , utf8-string

--- a/funflow/package.yaml
+++ b/funflow/package.yaml
@@ -33,7 +33,7 @@ dependencies:
   - store
   - temporary
   - text >= 2.0
-  - unix-compat
+  - unix
   - unliftio
   - unordered-containers
   - utf8-string

--- a/funflow/src/Funflow/Run.hs
+++ b/funflow/src/Funflow/Run.hs
@@ -84,7 +84,7 @@ import System.Directory (removeDirectory)
 import System.Directory.Funflow (moveDirectoryContent)
 import System.IO.Temp (withSystemTempDirectory)
 import System.Info (os)
-import System.PosixCompat.User (getEffectiveGroupID, getEffectiveUserID)
+import System.Posix.User (getEffectiveGroupID, getEffectiveUserID)
 
 -- * Flow execution
 


### PR DESCRIPTION
See

https://github.com/dhall-lang/dhall-haskell/pull/2496