### PR TITLE
Update github workflow versions

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -11,16 +11,16 @@ jobs:
 
     steps:
       # Setup
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: cachix/install-nix-action@v12
+      - uses: cachix/install-nix-action@v22
 
-      - uses: cachix/cachix-action@v10
+      - uses: cachix/cachix-action@v12
         with:
           name: funflow
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
-      - uses: actions/cache@v2.1.3
+      - uses: actions/cache@v3
         name: Cache ~/.stack
         with:
           path: ~/.stack
@@ -47,7 +47,7 @@ jobs:
       - name: Deploy docs
         # Push to GitHub Pages only on master
         if: github.ref == 'refs/heads/master'
-        uses: JamesIves/github-pages-deploy-action@v4.2.5
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
           folder: ./funflow-pages/result/funflow


### PR DESCRIPTION
This updates the external GitHub workflows to their latest versions and should resolve the CI failure in #216.